### PR TITLE
Added new types to support translation from xml spec of slicer CLI

### DIFF
--- a/girder_worker/format/__init__.py
+++ b/girder_worker/format/__init__.py
@@ -288,7 +288,19 @@ def import_default_converters():
 
     cur_path = os.path.dirname(os.path.realpath(__file__))
     import_converters([os.path.join(cur_path, t) for t in [
-        "table", "tree", "string", "number", "image", "directory", "boolean",
-        "netcdf", "python", "graph"]])
+        "boolean",
+        "directory",
+        "graph",
+        "image",
+        "integer",
+        "integer_list",
+        "netcdf",
+        "number",
+        "number_list",
+        "python",
+        "string",
+        "string_list",
+        "table",
+        "tree"]])
 
 import_default_converters()

--- a/girder_worker/format/integer/integer_to_json.json
+++ b/girder_worker/format/integer/integer_to_json.json
@@ -1,0 +1,7 @@
+{
+    "name": "Integer to JSON",
+    "inputs": [{"name": "input", "type": "integer", "format": "integer"}],
+    "outputs": [{"name": "output", "type": "integer", "format": "json"}],
+    "script_uri": "file://integer_to_json.py",
+    "mode": "python"
+}

--- a/girder_worker/format/integer/integer_to_json.py
+++ b/girder_worker/format/integer/integer_to_json.py
@@ -1,0 +1,2 @@
+import json
+output = json.dumps(input)

--- a/girder_worker/format/integer/json_to_integer.json
+++ b/girder_worker/format/integer/json_to_integer.json
@@ -1,0 +1,7 @@
+{
+    "name": "JSON to Integer",
+    "inputs": [{"name": "input", "type": "integer", "format": "json"}],
+    "outputs": [{"name": "output", "type": "integer", "format": "integer"}],
+    "script_uri": "file://json_to_integer.py",
+    "mode": "python"
+}

--- a/girder_worker/format/integer/json_to_integer.py
+++ b/girder_worker/format/integer/json_to_integer.py
@@ -1,0 +1,2 @@
+import json
+output = json.loads(input)

--- a/girder_worker/format/integer/validate_integer.json
+++ b/girder_worker/format/integer/validate_integer.json
@@ -1,0 +1,6 @@
+{
+    "inputs": [{"name": "input", "type": "integer", "format": "integer"}],
+    "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
+    "script": "output = isinstance(input, int)",
+    "mode": "python"
+}

--- a/girder_worker/format/integer/validate_json.json
+++ b/girder_worker/format/integer/validate_json.json
@@ -1,0 +1,7 @@
+{
+    "inputs": [{"name": "input", "type": "integer", "format": "json"}],
+    "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
+    "script": "output = isinstance(input, (str, unicode))",
+    "extensions": ["integer-json"],
+    "mode": "python"
+}

--- a/girder_worker/format/integer_list/integer_list_to_json.json
+++ b/girder_worker/format/integer_list/integer_list_to_json.json
@@ -1,0 +1,7 @@
+{
+    "name": "Integer List to JSON",
+    "inputs": [{"name": "input", "type": "integer_list", "format": "integer_list"}],
+    "outputs": [{"name": "output", "type": "integer_list", "format": "json"}],
+    "script_uri": "file://integer_list_to_json.py",
+    "mode": "python"
+}

--- a/girder_worker/format/integer_list/integer_list_to_json.py
+++ b/girder_worker/format/integer_list/integer_list_to_json.py
@@ -1,0 +1,2 @@
+import json
+output = json.dumps(input)

--- a/girder_worker/format/integer_list/json_to_integer_list.json
+++ b/girder_worker/format/integer_list/json_to_integer_list.json
@@ -1,0 +1,7 @@
+{
+    "name": "JSON to Integer List",
+    "inputs": [{"name": "input", "type": "integer_list", "format": "json"}],
+    "outputs": [{"name": "output", "type": "integer_list", "format": "integer_list"}],
+    "script_uri": "file://json_to_integer_list.py",
+    "mode": "python"
+}

--- a/girder_worker/format/integer_list/json_to_integer_list.py
+++ b/girder_worker/format/integer_list/json_to_integer_list.py
@@ -1,0 +1,2 @@
+import json
+output = json.loads(input)

--- a/girder_worker/format/integer_list/validate_integer_list.json
+++ b/girder_worker/format/integer_list/validate_integer_list.json
@@ -1,0 +1,6 @@
+{
+    "inputs": [{"name": "input", "type": "integer_list", "format": "integer_list"}],
+    "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
+    "script": "output = isinstance(input, list) and all([isinstance(elm, int) for elm in input])",
+    "mode": "python"
+}

--- a/girder_worker/format/integer_list/validate_json.json
+++ b/girder_worker/format/integer_list/validate_json.json
@@ -1,0 +1,6 @@
+{
+    "inputs": [{"name": "input", "type": "integer_list", "format": "json"}],
+    "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
+    "script": "output = isinstance(input, (str, unicode))",
+    "mode": "python"
+}

--- a/girder_worker/format/number_list/json_to_number_list.json
+++ b/girder_worker/format/number_list/json_to_number_list.json
@@ -1,0 +1,7 @@
+{
+    "name": "JSON to Number List",
+    "inputs": [{"name": "input", "type": "number_list", "format": "json"}],
+    "outputs": [{"name": "output", "type": "number_list", "format": "number_list"}],
+    "script_uri": "file://json_to_number_list.py",
+    "mode": "python"
+}

--- a/girder_worker/format/number_list/json_to_number_list.py
+++ b/girder_worker/format/number_list/json_to_number_list.py
@@ -1,0 +1,2 @@
+import json
+output = json.loads(input)

--- a/girder_worker/format/number_list/number_list_to_json.json
+++ b/girder_worker/format/number_list/number_list_to_json.json
@@ -1,0 +1,7 @@
+{
+    "name": "Number List to JSON",
+    "inputs": [{"name": "input", "type": "number_list", "format": "number_list"}],
+    "outputs": [{"name": "output", "type": "number_list", "format": "json"}],
+    "script_uri": "file://number_list_to_json.py",
+    "mode": "python"
+}

--- a/girder_worker/format/number_list/number_list_to_json.py
+++ b/girder_worker/format/number_list/number_list_to_json.py
@@ -1,0 +1,2 @@
+import json
+output = json.dumps(input)

--- a/girder_worker/format/number_list/validate_json.json
+++ b/girder_worker/format/number_list/validate_json.json
@@ -1,0 +1,6 @@
+{
+    "inputs": [{"name": "input", "type": "number_list", "format": "json"}],
+    "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
+    "script": "output = isinstance(input, (str, unicode))",
+    "mode": "python"
+}

--- a/girder_worker/format/number_list/validate_number_list.json
+++ b/girder_worker/format/number_list/validate_number_list.json
@@ -1,0 +1,6 @@
+{
+    "inputs": [{"name": "input", "type": "number_list", "format": "number_list"}],
+    "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
+    "script": "output = isinstance(input, list) and all([isinstance(elm, (int, float)) for elm in input])",
+    "mode": "python"
+}

--- a/girder_worker/format/string_list/json_to_string_list.json
+++ b/girder_worker/format/string_list/json_to_string_list.json
@@ -1,0 +1,7 @@
+{
+    "name": "JSON to String List",
+    "inputs": [{"name": "input", "type": "string_list", "format": "json"}],
+    "outputs": [{"name": "output", "type": "string_list", "format": "string_list"}],
+    "script_uri": "file://json_to_string_list.py",
+    "mode": "python"
+}

--- a/girder_worker/format/string_list/json_to_string_list.py
+++ b/girder_worker/format/string_list/json_to_string_list.py
@@ -1,0 +1,2 @@
+import json
+output = json.loads(input)

--- a/girder_worker/format/string_list/string_list_to_json.json
+++ b/girder_worker/format/string_list/string_list_to_json.json
@@ -1,0 +1,7 @@
+{
+    "name": "String List to JSON",
+    "inputs": [{"name": "input", "type": "string_list", "format": "string_list"}],
+    "outputs": [{"name": "output", "type": "string_list", "format": "json"}],
+    "script_uri": "file://string_list_to_json.py",
+    "mode": "python"
+}

--- a/girder_worker/format/string_list/string_list_to_json.py
+++ b/girder_worker/format/string_list/string_list_to_json.py
@@ -1,0 +1,2 @@
+import json
+output = json.dumps(input)

--- a/girder_worker/format/string_list/validate_json.json
+++ b/girder_worker/format/string_list/validate_json.json
@@ -1,0 +1,6 @@
+{
+    "inputs": [{"name": "input", "type": "string_list", "format": "json"}],
+    "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
+    "script": "output = isinstance(input, (str, unicode))",
+    "mode": "python"
+}

--- a/girder_worker/format/string_list/validate_string_list.json
+++ b/girder_worker/format/string_list/validate_string_list.json
@@ -1,0 +1,6 @@
+{
+    "inputs": [{"name": "input", "type": "string_list", "format": "string_list"}],
+    "outputs": [{"name": "output", "type": "boolean", "format": "boolean"}],
+    "script": "output = isinstance(input, list) and all([isinstance(elm, (str, unicode)) for elm in input])",
+    "mode": "python"
+}

--- a/tests/integer_list_test.py
+++ b/tests/integer_list_test.py
@@ -1,0 +1,81 @@
+import girder_worker
+import unittest
+
+
+class TestIntegerList(unittest.TestCase):
+
+    def setUp(self):
+        self.analysis = {
+            "name": "concatenate",
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "integer_list",
+                    "format": "integer_list",
+                    "default": {
+                        "format": "json",
+                        "data": "[0]"
+                    }
+                },
+                {
+                    "name": "b",
+                    "type": "integer_list",
+                    "format": "integer_list"
+                }
+            ],
+            "outputs": [{"name": "c",
+                         "type": "integer_list", "format": "integer_list"}],
+            "script": "c = a + b",
+            "mode": "python"
+        }
+
+    def test_integer(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "a": {"format": "integer_list", "data": [1, 2]},
+                "b": {"format": "integer_list", "data": [3, 4]}
+            },
+            outputs={
+                "c": {"format": "integer_list"}
+            })
+        self.assertEqual(outputs["c"]["format"], "integer_list")
+        self.assertEqual(outputs["c"]["data"], [1, 2, 3, 4])
+
+    def test_json(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "a": {"format": "json", "data": "[1, 2]"},
+                "b": {"format": "json", "data": "[3, 4]"}
+            },
+            outputs={
+                "c": {"format": "json"}
+            })
+        self.assertEqual(outputs["c"]["format"], "json")
+        self.assertEqual(outputs["c"]["data"], "[1, 2, 3, 4]")
+
+    def test_default(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "b": {"format": "integer_list", "data": [2]}
+            },
+            outputs={
+                "c": {"format": "integer_list"}
+            })
+        self.assertEqual(outputs["c"]["format"], "integer_list")
+        self.assertEqual(outputs["c"]["data"], [0, 2])
+
+        self.assertRaisesRegexp(
+            Exception, "^Required input 'b' not provided.$",
+            girder_worker.run, self.analysis,
+            inputs={
+                "a": {"format": "integer_list", "data": [2]}
+            },
+            outputs={
+                "c": {"format": "integer_list"}
+            })
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integer_test.py
+++ b/tests/integer_test.py
@@ -1,0 +1,80 @@
+import girder_worker
+import unittest
+
+
+class TestInteger(unittest.TestCase):
+
+    def setUp(self):
+        self.analysis = {
+            "name": "add",
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "integer",
+                    "format": "integer",
+                    "default": {
+                        "format": "json",
+                        "data": "0"
+                    }
+                },
+                {
+                    "name": "b",
+                    "type": "integer",
+                    "format": "integer"
+                }
+            ],
+            "outputs": [{"name": "c", "type": "integer", "format": "integer"}],
+            "script": "c = a + b",
+            "mode": "python"
+        }
+
+    def test_integer(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "a": {"format": "integer", "data": 1},
+                "b": {"format": "integer", "data": 2}
+            },
+            outputs={
+                "c": {"format": "integer"}
+            })
+        self.assertEqual(outputs["c"]["format"], "integer")
+        self.assertEqual(outputs["c"]["data"], 3)
+
+    def test_json(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "a": {"format": "json", "data": "1"},
+                "b": {"format": "json", "data": "2"}
+            },
+            outputs={
+                "c": {"format": "json"}
+            })
+        self.assertEqual(outputs["c"]["format"], "json")
+        self.assertEqual(outputs["c"]["data"], "3")
+
+    def test_default(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "b": {"format": "integer", "data": 2}
+            },
+            outputs={
+                "c": {"format": "integer"}
+            })
+        self.assertEqual(outputs["c"]["format"], "integer")
+        self.assertEqual(outputs["c"]["data"], 2)
+
+        self.assertRaisesRegexp(
+            Exception, "^Required input 'b' not provided.$",
+            girder_worker.run, self.analysis,
+            inputs={
+                "a": {"format": "integer", "data": 2}
+            },
+            outputs={
+                "c": {"format": "integer"}
+            })
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/number_list_test.py
+++ b/tests/number_list_test.py
@@ -1,0 +1,94 @@
+import girder_worker
+import unittest
+
+
+class TestNumberList(unittest.TestCase):
+
+    def setUp(self):
+        self.analysis = {
+            "name": "concatenate",
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "number_list",
+                    "format": "number_list",
+                    "default": {
+                        "format": "json",
+                        "data": "[0]"
+                    }
+                },
+                {
+                    "name": "b",
+                    "type": "number_list",
+                    "format": "number_list"
+                }
+            ],
+            "outputs": [{"name": "c",
+                         "type": "number_list", "format": "number_list"}],
+            "script": "c = a + b",
+            "mode": "python"
+        }
+
+    def test_numeric(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "a": {"format": "number_list", "data": [1, 2]},
+                "b": {"format": "number_list", "data": [3, 4]}
+            },
+            outputs={
+                "c": {"format": "number_list"}
+            })
+        self.assertEqual(outputs["c"]["format"], "number_list")
+        self.assertEqual(outputs["c"]["data"], [1, 2, 3, 4])
+
+    def test_json(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "a": {"format": "json", "data": "[1, 2]"},
+                "b": {"format": "json", "data": "[3, 4]"}
+            },
+            outputs={
+                "c": {"format": "json"}
+            })
+        self.assertEqual(outputs["c"]["format"], "json")
+        self.assertEqual(outputs["c"]["data"], "[1, 2, 3, 4]")
+
+    def test_float(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "a": {"format": "number_list", "data": [1.5, 2.5]},
+                "b": {"format": "number_list", "data": [3.5, 4.5]}
+            },
+            outputs={
+                "c": {"format": "number_list"}
+            })
+        self.assertEqual(outputs["c"]["format"], "number_list")
+        self.assertEqual(outputs["c"]["data"], [1.5, 2.5, 3.5, 4.5])
+
+    def test_default(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "b": {"format": "number_list", "data": [2]}
+            },
+            outputs={
+                "c": {"format": "number_list"}
+            })
+        self.assertEqual(outputs["c"]["format"], "number_list")
+        self.assertEqual(outputs["c"]["data"], [0, 2])
+
+        self.assertRaisesRegexp(
+            Exception, "^Required input 'b' not provided.$",
+            girder_worker.run, self.analysis,
+            inputs={
+                "a": {"format": "number_list", "data": [2]}
+            },
+            outputs={
+                "c": {"format": "number_list"}
+            })
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/string_list_test.py
+++ b/tests/string_list_test.py
@@ -1,0 +1,81 @@
+import girder_worker
+import unittest
+
+
+class TestStringList(unittest.TestCase):
+
+    def setUp(self):
+        self.analysis = {
+            "name": "concatenate",
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "string_list",
+                    "format": "string_list",
+                    "default": {
+                        "format": "json",
+                        "data": '["a"]'
+                    }
+                },
+                {
+                    "name": "b",
+                    "type": "string_list",
+                    "format": "string_list"
+                }
+            ],
+            "outputs": [{"name": "c",
+                         "type": "string_list", "format": "string_list"}],
+            "script": "c = a + b",
+            "mode": "python"
+        }
+
+    def test_string(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "a": {"format": "string_list", "data": ["a", "b"]},
+                "b": {"format": "string_list", "data": ["c", "d"]}
+            },
+            outputs={
+                "c": {"format": "string_list"}
+            })
+        self.assertEqual(outputs["c"]["format"], "string_list")
+        self.assertEqual(outputs["c"]["data"], ["a", "b", "c", "d"])
+
+    def test_json(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "a": {"format": "json", "data": '["a", "b"]'},
+                "b": {"format": "json", "data": '["c", "d"]'}
+            },
+            outputs={
+                "c": {"format": "json"}
+            })
+        self.assertEqual(outputs["c"]["format"], "json")
+        self.assertEqual(outputs["c"]["data"], '["a", "b", "c", "d"]')
+
+    def test_default(self):
+        outputs = girder_worker.run(
+            self.analysis,
+            inputs={
+                "b": {"format": "string_list", "data": ["b"]}
+            },
+            outputs={
+                "c": {"format": "string_list"}
+            })
+        self.assertEqual(outputs["c"]["format"], "string_list")
+        self.assertEqual(outputs["c"]["data"], ["a", "b"])
+
+        self.assertRaisesRegexp(
+            Exception, "^Required input 'b' not provided.$",
+            girder_worker.run, self.analysis,
+            inputs={
+                "a": {"format": "string_list", "data": ["a"]}
+            },
+            outputs={
+                "c": {"format": "string_list"}
+            })
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added new types -- integer, integer_list, number_list, string_list - to support translation from [xml spec of slicer execution model CLI](https://www.slicer.org/slicerWiki/index.php/Slicer3:Execution_Model_Documentation#XML_Schema)