### PR TITLE
Enforce more of PEP257 -- Docstring Conventions

### DIFF
--- a/girder_worker/specs/workflow.py
+++ b/girder_worker/specs/workflow.py
@@ -80,14 +80,16 @@ class Workflow(MutableMapping):
         self.__graph__.add_edge(t1, t2, metadata)
 
     def connect_tasks(self, *args, **kwargs):
-        """Connect two tasks together specifying which input ports connect
+        """
+        Connect two tasks together specifying which input ports connect
         to which output ports. This function takes either 1, 2 or 3 arguments.
         In the case of one argument it expects a list of tuples where the tuples
         are the first, second and third arguments to connect_tasks. If there are
         two arguments given they must be nodes in the workflow and ports must
         be specified as key word arguments.  If three arguments are supplied
         they should be node1, node2 and a dict of port connections where keys
-        are the output ports on node1 and value are the input ports on node2."""
+        are the output ports on node1 and value are the input ports on node2.
+        """
 
         # Single iterable argument - apply connect_tasks() to
         # each element in the iterable
@@ -157,8 +159,10 @@ class Workflow(MutableMapping):
         return internal_connections, input_ports, output_ports
 
     def _get_node_name(self, node, port, ports):
-        """Return 'node.port' if there is any other port under a different node
-        with the same name. Otherwise return 'port'"""
+        """
+        Return 'node.port' if there is any other port under a different node
+        with the same name. Otherwise return 'port'.
+        """
         if any(port in S for k, S in ports.items() if k != node):
             return '%s.%s' % (node, port)
         return port

--- a/tests/flake8.cfg
+++ b/tests/flake8.cfg
@@ -26,7 +26,7 @@ quotes: '
 #   ~~~~~~~~~~~~~~~~
 #   By including the flake8-docstrings module, we also will fail on PEP257
 #   errors (D...).  For the moment, suppress all of the D... errors that would
-#   cause us to fail.  We may want to revisit this to make out code more PEP257
+#   cause us to fail.  We may want to revisit this to make our code more PEP257
 #   conformant.
 #     D100 - Public module   (100) docstring missing.
 #     D101 - Public class    (101) docstring missing.
@@ -40,9 +40,6 @@ quotes: '
 #     D203 - 1 blank required before (203) class docstring.
 #     D204 - 1 blank required after  (204) class docstring.
 #     D205 - Blank line required between one-line summary and description.
-#     D208 - Docstring over-indented.
-#     D209 - Put multi-line docstring closing quotes on separate line.
-#     D300 - Use """triple double quotes""".
 #     D400 - First line should end with a period.
 #     D401 - First line should be in imperative mood.
 #     D402 - First line should not be the function's "signature".
@@ -56,4 +53,4 @@ quotes: '
 #     N803 - Argument name should be lowercase.
 #     N806 - Variable in function should be lowercase.
 #     N812 - Lowercase imported as non lowercase.
-ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D208,D209,D300,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812
+ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812

--- a/tests/spec_test.py
+++ b/tests/spec_test.py
@@ -80,8 +80,10 @@ class TestTaskSpec(TestCase):
     """Tests edge cases of the anonymous task spec."""
 
     def test_task_inputs_outputs_equality(self):
-        """Test input and output equality through specs, task __getitem__
-        interface and task __getattr__ interface."""
+        """
+        Test input and output equality through specs, task __getitem__
+        interface and task __getattr__ interface.
+        """
         inputs = sorted([
             {'name': 'a', 'type': 'string', 'format': 'text'},
             {'name': 'b', 'type': 'number', 'format': 'number'},
@@ -193,9 +195,11 @@ class TestTask(TestCase):
 class TestWorkflow(TestCase):
 
     def assertConsistent(self, system, ground, type_spec=None):
-        """Assert that the system and ground are consistent i.e., they
+        """
+        Assert that the system and ground are consistent i.e., they
         have the same order-variant dicts. We test raw dicts,
-        and Spec dicts and if present type specific dicts"""
+        and Spec dicts and if present type specific dicts.
+        """
 
         # Test dicts
         self.assertEquals(to_frozenset(system),
@@ -282,8 +286,10 @@ class TestWorkflow(TestCase):
         }
 
     def test_spec_class_generator(self):
-        """Instantiated classes from spec_class_generator should equal
-           their spec"""
+        """
+        Instantiated classes from spec_class_generator should equal
+        their spec.
+        """
         for spec in [self.add, self.add_three, self.add_two, self.multiply]:
             cls = spec_class_generator('cls', spec)
             self.assertEqual(cls(), spec)


### PR DESCRIPTION
Enforce the following warnings from flake8-docstrings for [PEP257](https://www.python.org/dev/peps/pep-0257/):

    D208 - Docstring over-indented.
    D209 - Put multi-line docstring closing quotes on separate line.
    D300 - Use """triple double quotes""".
