### PR TITLE
Create matching UID/GID inside docker containers

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -57,8 +57,8 @@ an argument can also be expanded, e.g.: ::
     "container_args": ["--some-parameter=$input{some_parameter_value}"]
 
 The temporary directory for the Girder Worker task is mapped into the running container
-under the directory ``/data``, so any files that were fetched into that temp directory
-will be available inside the running container at that path.
+under the directory ``/mnt/girder_worker/data``, so any files that were fetched into that
+temp directory will be available inside the running container at that path.
 
 By default, the image you specify will be pulled using the ``docker pull`` command.
 In some cases, you may not want to perform a pull, and instead want to rely on the
@@ -94,9 +94,9 @@ or standard error to become a task output, use the special output IDs ``_stdout`
         ...
 
 If you want to have your container write files that will be treated as outputs,
-write them into the ``/data`` directory inside the container, then declare them
+write them into the ``/mnt/girder_worker/data`` directory inside the container, then declare them
 in the task output specification with ``"target": "filepath"``. The following
-example shows how to specify a file written under ``/data/my_image.png`` as a
+example shows how to specify a file written to ``/mnt/girder_worker/data/my_image.png`` as a
 task output:
 
 .. code-block :: none
@@ -123,12 +123,12 @@ You don't have to use the output ID to specify the path; you can instead pass a
             "target": "filepath",
             "type": "string",
             "format": "text",
-            "path": "/data/some_subdirectory/my_image.png"
+            "path": "/mnt/girder_worker/data/some_subdirectory/my_image.png"
         }],
         ...
 
-Paths that are specified as relative paths are assumed to be relative to ``/data``.
-If you specify an absolute path, it must start with ``/data/``, otherwise an exception
+Paths that are specified as relative paths are assumed to be relative to ``/mnt/girder_worker/data``.
+If you specify an absolute path, it must start with ``/mnt/girder_worker/data/``, otherwise an exception
 will be thrown before the task is run. These conventions apply whether the path
 is specified in the ``id`` or ``path`` field.
 

--- a/girder_worker/plugins/docker/executor.py
+++ b/girder_worker/plugins/docker/executor.py
@@ -190,7 +190,7 @@ def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
     command = [
         'docker', 'run',
         '-v', '%s:%s' % (tempdir, DATA_VOLUME),
-        '-v', '%s:%s:%s' % (SCRIPTS_DIR, SCRIPTS_VOLUME, 'ro'),
+        '-v', '%s:%s:ro' % (SCRIPTS_DIR, SCRIPTS_VOLUME),
         '--entrypoint', os.path.join(SCRIPTS_VOLUME, 'entrypoint.sh')
     ] + task.get('docker_run_args', []) + [image] + pre_args + args
 

--- a/girder_worker/plugins/docker/scripts/entrypoint.sh
+++ b/girder_worker/plugins/docker/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Usage: entrypoint.sh <user_id> <group_id> <command to run>
-groupadd -o -g $2 -r worker
-useradd -o -u $1 --create-home -r -g worker worker
+sudo groupadd -o -g $2 -r worker
+sudo useradd -o -u $1 --create-home -r -g worker worker
 exec ${@:3}

--- a/girder_worker/plugins/docker/scripts/entrypoint.sh
+++ b/girder_worker/plugins/docker/scripts/entrypoint.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 
 # Usage: entrypoint.sh <user_id> <group_id> <command to run>
-groupadd -o -g $2 -r worker
-useradd -o -u $1 --create-home -r -g worker worker
-exec sudo -u worker ${@:3}
+
+# Add 'worker' user and group matching requested user_id and group_id
+group_id=$2
+user_id=$1
+groupadd -o -g $group_id -r worker
+useradd -o -u $user_id --create-home -r -g worker worker
+
+# Requote arguments to account for argument with spaces
+quoted_args=''
+for i in "${@:3}"; do
+    quoted_args="$quoted_args \"${i//\"/\\\"}\""
+done
+
+# Execute command as `worker` user
+export HOME=/home/worker
+exec su -m worker -c "$quoted_args"

--- a/girder_worker/plugins/docker/scripts/entrypoint.sh
+++ b/girder_worker/plugins/docker/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # Usage: entrypoint.sh <user_id> <group_id> <command to run>
-sudo groupadd -o -g $2 -r worker
-sudo useradd -o -u $1 --create-home -r -g worker worker
-exec ${@:3}
+groupadd -o -g $2 -r worker
+useradd -o -u $1 --create-home -r -g worker worker
+exec sudo -u worker ${@:3}

--- a/girder_worker/plugins/docker/scripts/entrypoint.sh
+++ b/girder_worker/plugins/docker/scripts/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Usage: entrypoint.sh <user_id> <group_id> <command to run>
+groupadd -o -g $2 -r worker
+useradd -o -u $1 --create-home -r -g worker worker
+exec ${@:3}


### PR DESCRIPTION
This means containers can do user info lookups based on the uid
of the host, which we must run as in order to properly share
volumes between the host and container.