### PR TITLE
Upgrade to Pillow 3.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ billiard==3.3.0.22
 celery==3.1.20
 kombu==3.0.33
 networkx==1.10
-Pillow==3.1.0
+Pillow==3.1.2
 pymongo==3.2
 pytz==2015.7
 requests==2.9.1


### PR DESCRIPTION
Several buffer overflow vulnerabilities have been fixes since
v3.1.0.