### PR TITLE
[Proposal] Proof of concept refactor to allow other tasks to be run by girder_worker

### DIFF
--- a/girder_worker/__main__.py
+++ b/girder_worker/__main__.py
@@ -1,53 +1,18 @@
-import girder_worker
-from girder_worker.format import conv_graph
-
-from .utils import JobManager, JobStatus
-from celery import Celery
-
-app = None
+import pkg_resources as pr
+from girder_worker import app
 
 
-def main():
-    global app
-    app = Celery(
-        main=girder_worker.config.get('celery', 'app_main'),
-        backend=girder_worker.config.get('celery', 'broker'),
-        broker=girder_worker.config.get('celery', 'broker'))
+def main(app):
+    includes = []
+    for ep in pr.iter_entry_points(group='girder_worker.tasks'):
+        module = ep.load()
+        includes.append(module.__name__)
 
-    @app.task
-    def run(*pargs, **kwargs):
-        jobInfo = kwargs.pop('jobInfo', {})
-        retval = 0
-
-        with JobManager(logPrint=jobInfo.get('logPrint', True),
-                        url=jobInfo.get('url'), method=jobInfo.get('method'),
-                        headers=jobInfo.get('headers'),
-                        reference=jobInfo.get('reference')) as jm:
-            kwargs['_job_manager'] = jm
-            kwargs['status'] = JobStatus.RUNNING
-            retval = girder_worker.run(*pargs, **kwargs)
-        return retval
-
-    @app.task
-    def convert(*pargs, **kwargs):
-        return girder_worker.convert(*pargs, **kwargs)
-
-    @app.task
-    def validators(*pargs, **kwargs):
-        _type, _format = pargs
-        nodes = []
-
-        for (node, data) in conv_graph.nodes(data=True):
-            if ((_type is None) or (_type == node.type)) and \
-               ((_format is None) or (_format == node.format)):
-                nodes.append({'type': node.type,
-                              'format': node.format,
-                              'validator': data})
-
-        return nodes
-
+    app.conf.update({
+        'CELERY_IMPORTS': includes
+    })
     app.worker_main()
 
 
 if __name__ == '__main__':
-    main()
+    main(app)

--- a/girder_worker/__main__.py
+++ b/girder_worker/__main__.py
@@ -2,7 +2,7 @@ import pkg_resources as pr
 from girder_worker import app
 
 
-def main(app):
+def main():
     includes = []
     for ep in pr.iter_entry_points(group='girder_worker.tasks'):
         module = ep.load()
@@ -15,4 +15,4 @@ def main(app):
 
 
 if __name__ == '__main__':
-    main(app)
+    main()

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,9 @@ setuptools.setup(
         'console_scripts': [
             'girder-worker = girder_worker.__main__:main',
             'girder-worker-config = girder_worker.configure:main'
+        ],
+        'girder_worker.tasks': [
+            "module = girder_worker"
         ]
     }
 )


### PR DESCRIPTION
## Overview

This is a PR that demonstrates a way of refactoring `girder_worker` to allow for celery tasks other than `run`, `convert` and `validators` to be run by external systems like girder's [worker](https://github.com/girder/girder/tree/master/plugins/worker) plugin It is not really intended to be merged but instead to provide a concrete proof of concept for discussion. 
## Motivation

Girder worker (previously romanesco)  provides a lot of functionality that is specific to running chains of analyses in different languages as well as converting data formats between these analyses. This involves specifications (or just 'specs') which include inputs, outputs and script locations. While these are critical components in the context of certain projects,  there are other projects that require distributed job management that do not need these features or are hampered by these features. _In these cases those projects are obligated to design their own solution_ which i would argue is sub-optimal.   

This PR refactors the current `girder_worker` application to provide a lower level API that provides access to celery for projects that do not need the higher level spec/input/output API.  The changes are intentionally minimal because this PR is intended to spark conversation about what other needs exist in terms of distributed job management. 
## Structure

In addition to this PR there is a [trivial example](https://github.com/kotfic/gwexample) of a separate package (or 'plugin',  or 'extension') that adds additional functionality to girder_worker. 

This PR moves the application out of the `main()` function and into the girder_worker **init** file. This allows for `app` to be imported and for additional tasks to be decorated (e.g. [here](https://github.com/kotfic/gwexample/blob/master/gwexample/analyses/tasks.py#L3) in the example extension) . 

The primary code retained in the girder_worker `main()` function is the call to app.worker_main() and new functionality that uses [setuptools entry points](https://pythonhosted.org/setuptools/setuptools.html#extensible-applications-and-frameworks) to discover available girder_worker tasks.  This can be see [here](https://github.com/kotfic/gwexample/blob/master/setup.py#L17-L21), where the example extension defines its tasks,  as well as [here](https://github.com/girder/girder_worker/blob/gw-proposal/setup.py#L116-L118) where girder defines the location of its internal tasks.

To test this you can checkout and install this branch of girder_worker in a virtual environment,  then checkout and install the [gwexample](https://github.com/kotfic/gwexample) repository.  From the girder_worker root directory running `girder-worker -l info` should produce the following output:

```
(gwtest) kotfic@minastirith:~/src/girder_worker_test/girder_worker$ girder-worker -l info

...

 -------------- celery@minastirith v3.1.20 (Cipater)
---- **** ----- 
--- * ***  * -- Linux-4.5.2-1-ARCH-x86_64-with-glibc2.2.5
-- * - **** --- 
- ** ---------- [config]
- ** ---------- .> app:         girder_worker:0x7faf653aaad0
- ** ---------- .> transport:   amqp://guest:**@localhost:5672//
- ** ---------- .> results:     amqp://guest@localhost/
- *** --- * --- .> concurrency: 32 (prefork)
-- ******* ---- 
--- ***** ----- [queues]
 -------------- .> celery           exchange=celery(direct) key=celery


[tasks]
  . girder_worker.convert
  . girder_worker.run
  . girder_worker.validators
  . gwexample.analyses.tasks.fib

[2016-05-16 13:54:47,311: INFO/MainProcess] Connected to amqp://guest:**@127.0.0.1:5672//
[2016-05-16 13:54:47,321: INFO/MainProcess] mingle: searching for neighbors
[2016-05-16 13:54:48,331: INFO/MainProcess] mingle: all alone
[2016-05-16 13:54:48,355: WARNING/MainProcess] celery@minastirith ready.

```

We can see that `gwexample.analyses.tasks.fib` is now available as a registered task in the celery process.
### Changes to girder's worker plugin

For this to be successful  the worker plugin will also need to be slightly refactored.  The actual task queued by the worker plugin is currently [hard coded](https://github.com/girder/girder/blob/master/plugins/worker/server/__init__.py#L83-L84) but this could be easily changed to provide generic access (as in the now defunct [celery_jobs plugin](https://github.com/girder/girder/blob/master/plugins/celery_jobs/server/__init__.py#L76-L77))
## Considerations

A refactor along these line would allow us to essentially remove the celery_jobs plugin (the new worker plugin will support the same functionality). It would provide an API for access through the worker plugin and the girder_worker process directly into the mechanics of celery which should allow for a wider set of uses cases.  This means individual extensions would be responsible for implementing updates back to the girder job.  I have some ideas about this based on celery [Signals](http://docs.celeryproject.org/en/latest/userguide/signals.html)  but will save that for further discussion. 
