### PR TITLE
Install python SSL support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ networkx==1.11
 Pillow==3.2.0
 pymongo==3.2.2
 pytz==2016.4
-requests==2.10.0
+requests[security]==2.10.0
 six==1.10.0
 wsgiref==0.1.2
 


### PR DESCRIPTION
This is to fix the warnings we are seeing on our challenge scoring logs:

```
/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/util/ssl_.py:120: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
```