### PR TITLE
New girder_io fetch option: "fetch_parent"

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -164,6 +164,7 @@ Girder IO
         (, "scheme": <"http" or "https", default is "http">)
         (, "token": <girder token used for authentication>)
         (, "resource_type": <"file", "item", or "folder", default is "file">)
+        (, "fetch_parent": <whether to download the whole parent resource as well, default is false>)
     }
 
 .. note :: For historical reasons, task inputs that do not specify a ``target`` field

--- a/girder_worker/plugins/girder_io/__init__.py
+++ b/girder_worker/plugins/girder_io/__init__.py
@@ -37,6 +37,7 @@ def _fetch_parent_item(file_id, client, dest):
     """
     target_file = client.getResource('file', file_id)
     item = client.getResource('item', target_file['itemId'])
+    dest = os.path.join(dest, client.transformFilename(item['name']))
     target_path = dest
 
     for file in client.listFile(item['_id']):
@@ -70,7 +71,7 @@ def fetch_handler(spec, **kwargs):
         client.downloadItem(spec['id'], kwargs['_tempdir'], filename)
     elif resource_type == 'file':
         if fetch_parent:
-            dest = _fetch_parent_item(spec['id'], client, dest)
+            dest = _fetch_parent_item(spec['id'], client, kwargs['_tempdir'])
         else:
             client.downloadFile(spec['id'], dest)
     else:

--- a/girder_worker/plugins/girder_io/__init__.py
+++ b/girder_worker/plugins/girder_io/__init__.py
@@ -17,14 +17,14 @@ def _init_client(spec, require_token=False):
         api_root = spec.get('api_root', '/api/v1')
         client = girder_client.GirderClient(
             host=spec['host'], scheme=scheme, apiRoot=api_root, port=port)
+    else:
+        raise Exception('You must pass either an api_url or host key for '
+                        'Girder input and output bindings.')
 
     if 'token' in spec:
         client.token = spec['token']
     elif require_token:
         raise Exception('You must pass a token for Girder authentication.')
-    else:
-        raise Exception('You must pass either an api_url or host key for '
-                        'Girder input and output bindings.')
 
     return client
 

--- a/girder_worker/plugins/girder_io/requirements.txt
+++ b/girder_worker/plugins/girder_io/requirements.txt
@@ -1,1 +1,1 @@
-girder-client==1.1.2
+girder-client==1.3.0


### PR DESCRIPTION
If set to true, this will cause the entire parent item of a file
to be downloaded rather than just the file itself, but the
underlying variable will still be set to the path of the
individual file rather than the containing item.