### PR TITLE
Add flush to JobManager to conform better to python io objects

### DIFF
--- a/girder_worker/utils.py
+++ b/girder_worker/utils.py
@@ -154,7 +154,11 @@ class JobManager(object):
             self._redirectPipes(True)
 
     def flush(self):
-        self._flush()
+        """
+        This API call is required to conform to file-like objects,
+        but in this case is a no-op to avoid circumventing rate-limiting.
+        """
+        pass
 
     def write(self, message, forceFlush=False):
         """

--- a/girder_worker/utils.py
+++ b/girder_worker/utils.py
@@ -153,6 +153,9 @@ class JobManager(object):
 
             self._redirectPipes(True)
 
+    def flush(self):
+        self._flush()
+
     def write(self, message, forceFlush=False):
         """
         Append a message to the log for this job. If logPrint is enabled, this


### PR DESCRIPTION
I am not entirely confident in this fix but it makes messages like this go away:

https://travis-ci.org/osumo/osumo/builds/144964779#L5146

```
'JobManager' object has no attribute 'flush'
```

I have seen this in osumo and flow. It seems `flush` is attempted to be called when errors happen.