### PR TITLE
Closes #74. Do not issue platform exception for docker

### DIFF
--- a/girder_worker/plugins/docker/__init__.py
+++ b/girder_worker/plugins/docker/__init__.py
@@ -1,7 +1,3 @@
-import os
-import platform
-
-
 def before_run(e):
     import executor
     if e.info['task']['mode'] == 'docker':
@@ -12,10 +8,5 @@ def load(params):
     from girder_worker.core import events, register_executor
     import executor
 
-    if (platform.system() != 'Linux' and
-            not os.environ.get('WORKER_FORCE_DOCKER_START')):
-        raise Exception('The docker plugin only works on Linux hosts due to '
-                        'mapping of shared volumes and pipes between host and '
-                        'container.')
     events.bind('run.before', 'docker', before_run)
     register_executor('docker', executor.run)

--- a/girder_worker/plugins/docker/plugin.cmake
+++ b/girder_worker/plugins/docker/plugin.cmake
@@ -1,2 +1,1 @@
 add_python_test(docker PLUGIN docker PLUGINS_ENABLED docker)
-set_property(TEST plugins.docker.docker APPEND PROPERTY ENVIRONMENT "WORKER_FORCE_DOCKER_START=true")


### PR DESCRIPTION
There are now native docker executables for other platforms besides Linux.

@jbeezley PTAL