### PR TITLE
Must coerce arg values to string to pass them in the CLI

### DIFF
--- a/girder_worker/plugins/docker/executor.py
+++ b/girder_worker/plugins/docker/executor.py
@@ -72,9 +72,9 @@ def _expand_args(args, inputs, taskInputs, tmpDir):
     for arg in args:
         for inputId in re.findall(regex, arg):
             if inputId in inputs:
-                transformed = _transform_path(inputs, taskInputs, inputId,
-                                              tmpDir)
-                arg = arg.replace('$input{%s}' % inputId, transformed)
+                transformed = _transform_path(
+                    inputs, taskInputs, inputId, tmpDir)
+                arg = arg.replace('$input{%s}' % inputId, str(transformed))
             elif inputId == '_tempdir':
                 arg = arg.replace('$input{_tempdir}', DATA_VOLUME)
 


### PR DESCRIPTION
This fixes a bug when parameters are passed in the JSON spec as numeric values rather than strings.