### PR TITLE
Docker integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
 before_install:
   - pip install -U pip six
   - pushd "${HOME}"
-  - if [ ! -f $HOME/cmake-3.2.2-Linux-x86_64/bin/cmake ] ; then  curl -L "http://cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz" | gunzip -c | tar x ; fi
+  - if [ ! -f $HOME/cmake-3.2.2-Linux-x86_64/bin/cmake ] ; then  curl -L http://cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz | gunzip -c | tar x ; fi
   - cd cmake-*/bin && export PATH="${PWD}:${PATH}"
   - popd
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   # download VTK
   - if [ ! -f $HOME/vtk-precise64/bin/vtkpython ] ; then curl -L https://data.kitware.com/api/v1/file/588b62958d777f4f3f30c773/download | tar zx -C ~ ; fi
   # install R
-  -  mkdir -p $HOME/local
+  - mkdir -p $HOME/local
   - if [ ! -f $HOME/local/env-arbor ] ; then curl -L https://data.kitware.com/api/v1/file/588b63c68d777f4f3f30c776/download | tar jx -C $HOME/local/ ; mv $HOME/local/env $HOME/local/env-arbor ; fi
   - source $HOME/local/env-arbor
   - R --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 
 services:
   - docker
+  - mongodb
 
 addons:
   apt:
@@ -34,14 +35,6 @@ before_script:
 before_install:
   - pip install -U pip six
   - pushd "${HOME}"
-  - curl "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGO_VERSION}.tgz" | gunzip -c | tar x
-  - cd mongodb-*/bin && export PATH="${PWD}:${PATH}"
-  - popd
-  - mkdir /tmp/db
-  - mongod --dbpath=/tmp/db >/dev/null 2>/dev/null &
-  - mongod --version
-  - pushd "${HOME}"
-  - curl -L "http://cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz" | gunzip -c | tar x
   - cd cmake-*/bin && export PATH="${PWD}:${PATH}"
   - popd
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
     - $HOME/local
     - $HOME/swift-0.96.1
     - $HOME/julia-0.4.2
+    - $HOME/vtk-precise64
 
 # environment variables
 env:
@@ -45,7 +46,7 @@ before_install:
   - popd
   - cmake --version
   # download VTK
-  - curl -L https://data.kitware.com/api/v1/file/588b62958d777f4f3f30c773/download | tar zx -C ~
+  - if [ ! -f $HOME/vtk-precise64/bin/vtkpython ] ; then curl -L https://data.kitware.com/api/v1/file/588b62958d777f4f3f30c773/download | tar zx -C ~ ; fi
   # install R
   -  mkdir -p $HOME/local
   - if [ ! -f $HOME/local/env-arbor ] ; then curl -L https://data.kitware.com/api/v1/file/588b63c68d777f4f3f30c776/download | tar jx -C $HOME/local/ ; mv $HOME/local/env $HOME/local/env-arbor ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ cache:
 env:
   - PYTHONPATH=~/vtk-precise64/lib/python2.7/site-packages:~/vtk-precise64/lib LD_LIBRARY_PATH=~/vtk-precise64/lib:~/local/lib:~/local/lib/R/lib
 
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+
 before_install:
   - pip install -U pip six
   - pushd "${HOME}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   - popd
   - cmake --version
   # download VTK
-  - curl -L http://midas3.kitware.com/midas/download/bitstream/366970/vtk-precise64-118242.tar.gz | tar zx -C ~
+  - curl -L https://data.kitware.com/api/v1/file/588b62958d777f4f3f30c773/download | tar zx -C ~
   # install R
   -  mkdir -p $HOME/local
   - if [ ! -f $HOME/local/env-arbor ] ; then curl -L https://data.kitware.com/api/v1/file/588b63c68d777f4f3f30c776/download | tar jx -C $HOME/local/ ; mv $HOME/local/env $HOME/local/env-arbor ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,8 @@ before_install:
   - sleep 3
   - $SPARK_HOME/sbin/start-slave.sh worker1 spark://localhost:7077
   # install swift
-  - export PATH=$PATH:$HOME/swift-0.96.1/bin
-  - swift --version || curl -L http://swiftlang.org/packages/swift-0.96.1.tar.gz | tar zx -C ~
+  - export PATH=$PATH:$HOME/swift-0.96.2/bin
+  - swift --version || curl -L https://data.kitware.com/api/v1/file/588b61cf8d777f4f3f30c770/download | tar zx -C ~
   - swift --version
   # install julia
   - export JULIA_INSTALL_HOME=$HOME/julia-0.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
     - $HOME/swift-0.96.1
     - $HOME/julia-0.4.2
     - $HOME/vtk-precise64
+    - $HOME/cmake-3.2.2-Linux-x86_64
 
 # environment variables
 env:
@@ -35,6 +36,7 @@ before_script:
 before_install:
   - pip install -U pip six
   - pushd "${HOME}"
+  - if [ ! -f $HOME/cmake-3.2.2-Linux-x86_64/bin/cmake ] ; then  curl -L "http://cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz" | gunzip -c | tar x ; fi
   - cd cmake-*/bin && export PATH="${PWD}:${PATH}"
   - popd
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 
 sudo: false
 
+services:
+  - docker
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,8 @@ before_install:
   # download VTK
   - curl -L http://midas3.kitware.com/midas/download/bitstream/366970/vtk-precise64-118242.tar.gz | tar zx -C ~
   # install R
-  - mkdir -p $HOME/local
-  - if [ ! -f $HOME/local/env-R ] ; then curl -L http://midas3.kitware.com/midas/download/bitstream/457205/R_3.2.0.tar.bz2 | tar jx -C $HOME/local/ ; mv $HOME/local/env $HOME/local/env-R ; fi
-  - source $HOME/local/env-R
-  - if [ ! -f $HOME/local/env-arbor ] ; then curl -L http://midas3.kitware.com/midas/download/bitstream/457206/aRbor-packages_1.0.0.tar.bz2 | tar jx -C $HOME/local/ ; mv $HOME/local/env $HOME/local/env-arbor ; fi
+  -  mkdir -p $HOME/local
+  - if [ ! -f $HOME/local/env-arbor ] ; then curl -L https://data.kitware.com/api/v1/file/588b63c68d777f4f3f30c776/download | tar jx -C $HOME/local/ ; mv $HOME/local/env $HOME/local/env-arbor ; fi
   - source $HOME/local/env-arbor
   - R --version
   - R -e '.libPaths(); sessionInfo()'

--- a/girder_worker/plugins/docker/plugin.cmake
+++ b/girder_worker/plugins/docker/plugin.cmake
@@ -1,1 +1,2 @@
 add_python_test(docker PLUGIN docker PLUGINS_ENABLED docker)
+add_python_test(docker_integration PLUGIN docker PLUGINS_ENABLED docker)

--- a/girder_worker/plugins/docker/tests/docker_integration_test.py
+++ b/girder_worker/plugins/docker/tests/docker_integration_test.py
@@ -1,5 +1,4 @@
 import ConfigParser
-import girder_worker
 import os
 import shutil
 import six
@@ -7,6 +6,7 @@ import stat
 import sys
 import unittest
 
+import girder_worker
 from girder_worker.core import run, io
 
 test_image = 'girder/girder_worker_test:latest'

--- a/girder_worker/plugins/docker/tests/docker_integration_test.py
+++ b/girder_worker/plugins/docker/tests/docker_integration_test.py
@@ -1,0 +1,278 @@
+import ConfigParser
+import girder_worker
+import os
+import shutil
+import six
+import stat
+import sys
+import unittest
+
+from girder_worker.core import run, io
+
+test_image = 'cjh1/girder_worker:test'
+
+def setUpModule():
+    global _tmp
+    _tmp = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), '_tmp', 'docker')
+    girder_worker.config.set('girder_worker', 'tmp_root', _tmp)
+    try:
+        girder_worker.config.add_section('docker')
+    except ConfigParser.DuplicateSectionError:
+        pass
+
+    if os.path.isdir(_tmp):
+        shutil.rmtree(_tmp)
+
+
+def tearDownModule():
+    if os.path.isdir(_tmp):
+        shutil.rmtree(_tmp)
+
+
+class TestDockerMode(unittest.TestCase):
+    """
+    Integration tests that call out to docker rather than using mocks.
+    """
+
+    def setUp(self):
+        self._test_message = 'Hello from girder_worker!'
+        self._tmp = os.path.join(_tmp, 'testing')
+        if not os.path.isdir(self._tmp):
+            os.makedirs(self._tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp)
+
+    def testDockerModeStdio(self):
+        """
+        Test writing to stdout.
+        """
+
+        task = {
+            'mode': 'docker',
+            'docker_image': test_image,
+            'pull_image': True,
+            'container_args': ['$input{test_mode}', '$input{message}'],
+            'inputs': [{
+                'id': 'test_mode',
+                'name': '',
+                'format': 'string',
+                'type': 'string'
+            }, {
+                'id': 'message',
+                'name': '',
+                'format': 'string',
+                'type': 'string'
+            }],
+            'outputs': []
+        }
+
+        inputs = {
+            'test_mode': {
+                'format': 'string',
+                'data': 'stdio'
+            },
+            'message': {
+                'format': 'string',
+                'data': self._test_message
+            }
+        }
+
+        _old = sys.stdout
+        mockedStdOut = six.StringIO()
+        sys.stdout = mockedStdOut
+        run(
+            task, inputs=inputs, _tempdir=self._tmp, cleanup=True, validate=False,
+            auto_convert=False)
+        sys.stdout = _old
+        lines = mockedStdOut.getvalue().splitlines()
+        self.assertEqual(lines[-2], self._test_message)
+        self.assertEqual(
+            lines[-1], 'Garbage collecting old containers and images.')
+
+        task = {
+            'mode': 'docker',
+            'docker_image': test_image,
+            'pull_image': True,
+            'container_args': ['$input{test_mode}', '$input{message}'],
+            'inputs': [{
+                'id': 'test_mode',
+                'name': '',
+                'format': 'string',
+                'type': 'string'
+            }, {
+                'id': 'message',
+                'name': '',
+                'format': 'string',
+                'type': 'string'
+            }],
+            'outputs': []
+        }
+        _old = sys.stdout
+        mockedStdOut = six.StringIO()
+        sys.stdout = mockedStdOut
+        run(
+            task, inputs=inputs, cleanup=True, validate=False,
+            auto_convert=False)
+        sys.stdout = _old
+
+        lines = mockedStdOut.getvalue().splitlines()
+        self.assertEqual(lines[-2], self._test_message)
+        self.assertEqual(
+            lines[-1], 'Garbage collecting old containers and images.')
+
+        # Test _stdout
+        task['outputs'] = [{
+            'id': '_stdout',
+            'format': 'string',
+            'type': 'string'
+        }]
+
+        _old = sys.stdout
+        mockedStdOut = six.StringIO()
+        sys.stdout = mockedStdOut
+        out = run(
+            task, inputs=inputs, cleanup=False, validate=False,
+            auto_convert=False)
+        sys.stdout = _old
+
+        lines = mockedStdOut.getvalue().splitlines()
+        message = '%s\n' % self._test_message
+        self.assertTrue(message not in lines)
+        self.assertEqual(out['_stdout']['data'], message)
+
+
+    def testDockerModeOutputPipes(self):
+        """
+        Test writing to named output pipe.
+        """
+        task = {
+            'mode': 'docker',
+            'docker_image': test_image,
+            'pull_image': True,
+            'container_args': ['$input{test_mode}', '$input{message}'],
+            'inputs': [{
+                'id': 'test_mode',
+                'name': '',
+                'format': 'string',
+                'type': 'string'
+            }, {
+                'id': 'message',
+                'name': '',
+                'format': 'string',
+                'type': 'string'
+            }],
+            'outputs': [{
+                'id': 'output_pipe',
+                'format': 'text',
+                'type': 'string',
+                'target': 'filepath',
+                'stream': True
+            }]
+        }
+
+        outputs = {
+            'output_pipe': {
+                'mode': 'capture'
+            }
+        }
+
+        inputs = {
+            'test_mode': {
+                'format': 'string',
+                'data': 'output_pipe'
+            },
+            'message': {
+                'format': 'string',
+                'data': self._test_message,
+            }
+        }
+
+        class CaptureAdapter(girder_worker.core.utils.StreamPushAdapter):
+            message = ''
+
+            def write(self, buf):
+                CaptureAdapter.message += buf
+
+        # Mock out the stream adapter
+        io.register_stream_push_adapter('capture', CaptureAdapter)
+
+        outputs = run(
+            task, inputs=inputs, outputs=outputs, _tempdir=self._tmp, cleanup=False)
+
+        # Make sure pipe was created inside the temp dir
+        pipe = os.path.join(self._tmp, 'output_pipe')
+        self.assertTrue(os.path.exists(pipe))
+        self.assertTrue(stat.S_ISFIFO(os.stat(pipe).st_mode))
+        # Make use piped output was write to adapter
+        self.assertEqual(CaptureAdapter.message, self._test_message)
+
+    def testDockerModeInputPipes(self):
+        """
+        Test reading from named output pipe.
+        """
+
+        task = {
+            'mode': 'docker',
+            'docker_image': test_image,
+            'pull_image': True,
+            'container_args': ['$input{test_mode}', '$input{message}'],
+            'inputs': [{
+                'id': 'test_mode',
+                'name': '',
+                'format': 'string',
+                'type': 'string'
+            }, {
+                'id': 'message',
+                'name': '',
+                'format': 'string',
+                'type': 'string'
+            }, {
+                'id': 'input_pipe',
+                'format': 'string',
+                'type': 'string',
+                'target': 'filepath',
+                'stream': True
+            }],
+            'outputs': [{
+                'id': '_stdout',
+                'format': 'string',
+                'type': 'string'
+            }]
+        }
+
+        inputs = {
+            'test_mode': {
+                'format': 'string',
+                'data': 'input_pipe'
+            },
+            'message': {
+                'format': 'string',
+                'data': self._test_message
+            },
+            'input_pipe': {
+                'mode': 'static',
+                'data': self._test_message
+            }
+        }
+
+        # Mock out the stream adapter
+        class StaticAdapter(girder_worker.core.utils.StreamFetchAdapter):
+
+            def __init__(self, spec):
+                self._data = six.BytesIO(spec['data'])
+
+            def read(self, buf_len):
+                return self._data.read(buf_len)
+
+        io.register_stream_fetch_adapter('static', StaticAdapter)
+
+        output = run(
+            task, inputs=inputs, outputs={}, _tempdir=self._tmp, cleanup=True)
+
+        # Make sure pipe was created inside the temp dir
+        pipe = os.path.join(self._tmp, 'input_pipe')
+        self.assertTrue(os.path.exists(pipe))
+        self.assertTrue(stat.S_ISFIFO(os.stat(pipe).st_mode))
+        self.assertEqual(output['_stdout']['data'].rstrip(), self._test_message)

--- a/girder_worker/plugins/docker/tests/docker_integration_test.py
+++ b/girder_worker/plugins/docker/tests/docker_integration_test.py
@@ -81,13 +81,13 @@ class TestDockerMode(unittest.TestCase):
         }
 
         _old = sys.stdout
-        mockedStdOut = six.StringIO()
-        sys.stdout = mockedStdOut
+        stdout_captor = six.StringIO()
+        sys.stdout = stdout_captor
         run(
             task, inputs=inputs, _tempdir=self._tmp, cleanup=True, validate=False,
             auto_convert=False)
         sys.stdout = _old
-        lines = mockedStdOut.getvalue().splitlines()
+        lines = stdout_captor.getvalue().splitlines()
         self.assertEqual(lines[-2], self._test_message)
         self.assertEqual(
             lines[-1], 'Garbage collecting old containers and images.')
@@ -111,14 +111,14 @@ class TestDockerMode(unittest.TestCase):
             'outputs': []
         }
         _old = sys.stdout
-        mockedStdOut = six.StringIO()
-        sys.stdout = mockedStdOut
+        stdout_captor = six.StringIO()
+        sys.stdout = stdout_captor
         run(
             task, inputs=inputs, cleanup=True, validate=False,
             auto_convert=False)
         sys.stdout = _old
 
-        lines = mockedStdOut.getvalue().splitlines()
+        lines = stdout_captor.getvalue().splitlines()
         self.assertEqual(lines[-2], self._test_message)
         self.assertEqual(
             lines[-1], 'Garbage collecting old containers and images.')
@@ -131,14 +131,14 @@ class TestDockerMode(unittest.TestCase):
         }]
 
         _old = sys.stdout
-        mockedStdOut = six.StringIO()
-        sys.stdout = mockedStdOut
+        stdout_captor = six.StringIO()
+        sys.stdout = stdout_captor
         out = run(
             task, inputs=inputs, cleanup=False, validate=False,
             auto_convert=False)
         sys.stdout = _old
 
-        lines = mockedStdOut.getvalue().splitlines()
+        lines = stdout_captor.getvalue().splitlines()
         message = '%s\n' % self._test_message
         self.assertTrue(message not in lines)
         self.assertEqual(out['_stdout']['data'], message)

--- a/girder_worker/plugins/docker/tests/docker_integration_test.py
+++ b/girder_worker/plugins/docker/tests/docker_integration_test.py
@@ -9,7 +9,7 @@ import unittest
 
 from girder_worker.core import run, io
 
-test_image = 'cjh1/girder_worker:test'
+test_image = 'girder/girder_worker_test:latest'
 
 
 def setUpModule():

--- a/girder_worker/plugins/docker/tests/docker_integration_test.py
+++ b/girder_worker/plugins/docker/tests/docker_integration_test.py
@@ -11,6 +11,7 @@ from girder_worker.core import run, io
 
 test_image = 'cjh1/girder_worker:test'
 
+
 def setUpModule():
     global _tmp
     _tmp = os.path.join(
@@ -141,7 +142,6 @@ class TestDockerMode(unittest.TestCase):
         message = '%s\n' % self._test_message
         self.assertTrue(message not in lines)
         self.assertEqual(out['_stdout']['data'], message)
-
 
     def testDockerModeOutputPipes(self):
         """

--- a/girder_worker/plugins/docker/tests/test_image/Dockerfile
+++ b/girder_worker/plugins/docker/tests/test_image/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:2.7-alpine
+MAINTAINER Chris Harris <chris.harris@kitware.com>
+
+COPY . $PWD
+
+ENTRYPOINT ["python", "./test.py"]

--- a/girder_worker/plugins/docker/tests/test_image/test.py
+++ b/girder_worker/plugins/docker/tests/test_image/test.py
@@ -1,0 +1,20 @@
+import sys
+
+if len(sys.argv) == 3:
+    mode = sys.argv[1]
+    message = sys.argv[2]
+
+    if mode == 'stdio':
+        print(message)
+    elif mode == 'output_pipe':
+        with open('/mnt/girder_worker/data/output_pipe', 'w') as fp:
+            fp.write(message)
+    elif mode == 'input_pipe':
+        with open('/mnt/girder_worker/data/input_pipe', 'r') as fp:
+            print(fp.read())
+    else:
+        sys.stderr.write('Invalid test mode: "%s".\n' % mode)
+        sys.exit(-1)
+else:
+    sys.stderr.write('Insufficient arguments.\n')
+    sys.exit(-1)


### PR DESCRIPTION
Wow, that was quite the odyssey! :ocean: 

So using the docker service in travis bumped the OS version to 14.0.4. This broke our R build so I had to rebuild it against 14.0.4. I made some other update to our travis builds as well:

- We are now only pulling from data.kitware.com ( no more midas :smile: )
- swift-langs downloads seem to be broken, so I moved this to data.kitware.com
- I added more caching to try a speed things up.
- Rather than install mongodb we now use mongodb service 
- One of test started to fail on 14.0.4, it needs X so we now start xvfb, not sure how this ever worked!

And finally what I was trying to ... a docker integration test ...

If someone who has access to the dockerhub girder org can create us a girder_worker repo, I can push my test image there and pull from there. Its currently under my account.