### PR TITLE
Support "params" in HTTP outputs

### DIFF
--- a/docs/api-docs.rst
+++ b/docs/api-docs.rst
@@ -254,6 +254,7 @@ return value of :py:func:`girder_worker.run`.
         "format": <data format>
         (, "headers": <dict of HTTP headers to send with the request>)
         (, "method": <http method to use, default is "POST">)
+        (, "params": <dict of HTTP query parameters to send with the request>)
     }
 
     <OUTPUT_BINDING_LOCAL> ::= {

--- a/girder_worker/core/io/http.py
+++ b/girder_worker/core/io/http.py
@@ -188,11 +188,11 @@ def push(data, spec, **kwargs):
         with open(data, 'rb') as fd:
             request = requests.request(
                 method, url, headers=spec.get('headers', {}), data=fd,
-                allow_redirects=True)
+                params=spec.get('params', {}), allow_redirects=True)
     elif target == 'memory':
         request = requests.request(
             method, url, headers=spec.get('headers', {}), data=data,
-            allow_redirects=True)
+            params=spec.get('params', {}), allow_redirects=True)
     else:
         raise Exception('Invalid HTTP fetch target: ' + target)
 

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -144,6 +144,7 @@ with open(file) as f:
                 'type': 'string',
                 'url': 'https://output.com/location.out',
                 'headers': {'foo': 'bar'},
+                'params': {'queryParam': 'value'},
                 'method': 'PUT'
             }
         }
@@ -160,6 +161,7 @@ with open(file) as f:
                 # The input fetch request
                 return 'dummy file contents'
             elif url.netloc == 'output.com' and url.path == '/location.out':
+                self.assertEqual(url.query, 'queryParam=value')
                 received.append(request.body)
                 return ''
             elif (url.netloc == 'jobstatus' and url.path == '/' and


### PR DESCRIPTION
@jeffbaumes this fixes the issue you were seeing in item_tasks; apparently we did not support query params for HTTP outputs prior to this change.