### PR TITLE
Create a cleanup entrypoint, move docker GC to it

### DIFF
--- a/girder_worker/core/cleanup.py
+++ b/girder_worker/core/cleanup.py
@@ -1,0 +1,5 @@
+from . import events
+
+
+def main():
+    events.trigger('cleanup')

--- a/girder_worker/plugins/docker/__init__.py
+++ b/girder_worker/plugins/docker/__init__.py
@@ -2,7 +2,11 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 from girder_worker import config
+
+# Minimum interval in seconds at which to run the docker-gc script
+MIN_GC_INTERVAL = 600
 
 
 def before_run(e):
@@ -28,6 +32,13 @@ def docker_gc(e):
     the same directory as this file. After that, deletes all images that are
     no longer used by any containers.
     """
+    stampfile = os.path.join(config.get('girder_worker', 'tmp_root'), '.dockergcstamp')
+    if os.path.exists(stampfile) and time.time() - os.path.getmtime(stampfile) < MIN_GC_INTERVAL:
+        return
+    else:  # touch the file
+        with open(stampfile, 'w') as f:
+            f.write('')
+
     print('Garbage collecting docker containers and images.')
     gc_dir = tempfile.mkdtemp()
 

--- a/girder_worker/plugins/docker/__init__.py
+++ b/girder_worker/plugins/docker/__init__.py
@@ -1,4 +1,8 @@
+import os
+import shutil
 import subprocess
+import tempfile
+from girder_worker import config
 
 
 def before_run(e):
@@ -7,7 +11,58 @@ def before_run(e):
         executor.validate_task_outputs(e.info['task_outputs'])
 
 
-def cleanup(e):
+def _read_from_config(key, default):
+    """
+    Helper to read Docker specific config values from the worker config files.
+    """
+    if config.has_option('docker', key):
+        return config.get('docker', key)
+    else:
+        return default
+
+
+def docker_gc(e):
+    """
+    Garbage collect containers that have not been run in the last hour using the
+    https://github.com/spotify/docker-gc project's script, which is copied in
+    the same directory as this file. After that, deletes all images that are
+    no longer used by any containers.
+    """
+    print('Garbage collecting docker containers and images.')
+    gc_dir = tempfile.mkdtemp()
+
+    try:
+        script = os.path.join(os.path.dirname(__file__), 'docker-gc')
+        if not os.path.isfile(script):
+            raise Exception('Docker GC script %s not found.' % script)
+        if not os.access(script, os.X_OK):
+            raise Exception('Docker GC script %s is not executable.' % script)
+
+        env = os.environ.copy()
+        env['FORCE_CONTAINER_REMOVAL'] = '1'
+        env['STATE_DIR'] = gc_dir
+        env['PID_DIR'] = gc_dir
+        env['GRACE_PERIOD_SECONDS'] = str(_read_from_config('cache_timeout', 3600))
+
+        # Handle excluded images
+        excluded = _read_from_config('exclude_images', '').split(',')
+        excluded = [img for img in excluded if img.strip()]
+        if excluded:
+            exclude_file = os.path.join(gc_dir, '.docker-gc-exclude')
+            with open(exclude_file, 'w') as fd:
+                fd.write('\n'.join(excluded) + '\n')
+            env['EXCLUDE_FROM_GC'] = exclude_file
+
+        p = subprocess.Popen(args=(script,), env=env)
+        p.wait()  # Wait for garbage collection subprocess to finish
+
+        if p.returncode != 0:
+            raise Exception('Docker GC returned code %d.' % p.returncode)
+    finally:
+        shutil.rmtree(gc_dir)
+
+
+def task_cleanup(e):
     """
     Since files written by docker containers are owned by root, we can't
     clean them up in the worker process since that typically doesn't run
@@ -34,5 +89,6 @@ def load(params):
     import executor
 
     events.bind('run.before', params['name'], before_run)
-    events.bind('run.finally', params['name'], cleanup)
+    events.bind('run.finally', params['name'], task_cleanup)
+    events.bind('cleanup', params['name'], docker_gc)
     register_executor('docker', executor.run)

--- a/girder_worker/plugins/docker/executor.py
+++ b/girder_worker/plugins/docker/executor.py
@@ -2,7 +2,6 @@ import os
 import re
 import subprocess
 
-from girder_worker import config
 from girder_worker.core import TaskSpecValidationError, utils
 from girder_worker.core.io import make_stream_fetch_adapter, make_stream_push_adapter
 
@@ -23,16 +22,6 @@ def _pull_image(image):
         print('STDERR: ' + stderr)
 
         raise Exception('Docker pull returned code {}.'.format(p.returncode))
-
-
-def _read_from_config(key, default):
-    """
-    Helper to read Docker specific config values from the worker config files.
-    """
-    if config.has_option('docker', key):
-        return config.get('docker', key)
-    else:
-        return default
 
 
 def _transform_path(inputs, taskInputs, inputId, tmpDir):
@@ -83,49 +72,6 @@ def _expand_args(args, inputs, taskInputs, tmpDir):
             newArgs.append(arg)
 
     return newArgs
-
-
-def _docker_gc(tempdir):
-    """
-    Garbage collect containers that have not been run in the last hour using the
-    https://github.com/spotify/docker-gc project's script, which is copied in
-    the same directory as this file. After that, deletes all images that are
-    no longer used by any containers.
-
-    This starts the script in the background and returns the subprocess object.
-    Waiting for the subprocess to complete is left to the caller, in case they
-    wish to do something in parallel with the garbage collection.
-
-    Standard output and standard error pipes from this subprocess are the same
-    as the current process to avoid blocking on a full buffer.
-
-    :param tempdir: Temporary directory where the GC should write files.
-    :type tempdir: str
-    :returns: The process object that was created.
-    :rtype: `subprocess.Popen`
-    """
-    script = os.path.join(os.path.dirname(__file__), 'docker-gc')
-    if not os.path.isfile(script):
-        raise Exception('Docker GC script %s not found.' % script)
-    if not os.access(script, os.X_OK):
-        raise Exception('Docker GC script %s is not executable.' % script)
-
-    env = os.environ.copy()
-    env['FORCE_CONTAINER_REMOVAL'] = '1'
-    env['STATE_DIR'] = tempdir
-    env['PID_DIR'] = tempdir
-    env['GRACE_PERIOD_SECONDS'] = str(_read_from_config('cache_timeout', 3600))
-
-    # Handle excluded images
-    excluded = _read_from_config('exclude_images', '').split(',')
-    excluded = [img for img in excluded if img.strip()]
-    if excluded:
-        exclude_file = os.path.join(tempdir, '.docker-gc-exclude')
-        with open(exclude_file, 'w') as fd:
-            fd.write('\n'.join(excluded) + '\n')
-        env['EXCLUDE_FROM_GC'] = exclude_file
-
-    return subprocess.Popen(args=(script,), env=env)
 
 
 def validate_task_outputs(task_outputs):
@@ -242,11 +188,6 @@ def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
     if p.returncode != 0:
         raise Exception('Error: docker run returned code %d.' % p.returncode)
 
-    print('Garbage collecting old containers and images.')
-    gc_dir = os.path.join(tempdir, 'docker_gc_scratch')
-    os.mkdir(gc_dir)
-    p = _docker_gc(gc_dir)
-
     for name, spec in task_outputs.iteritems():
         if spec.get('target') == 'filepath' and not spec.get('stream'):
             path = spec.get('path', name)
@@ -259,8 +200,3 @@ def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
             if not os.path.exists(path):
                 raise Exception('Output filepath %s does not exist.' % path)
             outputs[name]['script_data'] = path
-
-    p.wait()  # Wait for garbage collection subprocess to finish
-
-    if p.returncode != 0:
-        raise Exception('Docker GC returned code %d.' % p.returncode)

--- a/girder_worker/plugins/docker/tests/docker_integration_test.py
+++ b/girder_worker/plugins/docker/tests/docker_integration_test.py
@@ -88,9 +88,7 @@ class TestDockerMode(unittest.TestCase):
             auto_convert=False)
         sys.stdout = _old
         lines = stdout_captor.getvalue().splitlines()
-        self.assertEqual(lines[-2], self._test_message)
-        self.assertEqual(
-            lines[-1], 'Garbage collecting old containers and images.')
+        self.assertEqual(lines[-1], self._test_message)
 
         task = {
             'mode': 'docker',
@@ -119,9 +117,7 @@ class TestDockerMode(unittest.TestCase):
         sys.stdout = _old
 
         lines = stdout_captor.getvalue().splitlines()
-        self.assertEqual(lines[-2], self._test_message)
-        self.assertEqual(
-            lines[-1], 'Garbage collecting old containers and images.')
+        self.assertEqual(lines[-1], self._test_message)
 
         # Test _stdout
         task['outputs'] = [{

--- a/girder_worker/plugins/docker/tests/docker_test.py
+++ b/girder_worker/plugins/docker/tests/docker_test.py
@@ -194,6 +194,7 @@ class TestDockerMode(unittest.TestCase):
 
     @mock.patch('subprocess.Popen')
     def testCleanupHook(self, mockPopen):
+        os.makedirs(_tmp)
         mockPopen.return_value = processMock
         girder_worker.config.set('docker', 'cache_timeout', '123456')
         girder_worker.config.set('docker', 'exclude_images', 'test/test:latest')

--- a/girder_worker/tasks.py
+++ b/girder_worker/tasks.py
@@ -3,7 +3,11 @@ from .core.utils import JobManager, JobStatus
 from .app import app
 
 
-@app.task(name='girder_worker.run')
+def _cleanup(*args, **kwargs):
+    core.events.trigger('cleanup')
+
+
+@app.task(name='girder_worker.run', after_return=_cleanup)
 def run(*pargs, **kwargs):
     jobInfo = kwargs.pop('jobInfo', {})
     retval = 0

--- a/setup.py
+++ b/setup.py
@@ -159,6 +159,7 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'girder-worker = girder_worker.__main__:main',
+            'girder-worker-cleanup = girder_worker.core.cleanup:main',
             'girder-worker-config = girder_worker.configure:main'
         ],
         'girder_worker_plugins': [


### PR DESCRIPTION
This allows external services to schedule periodic worker
cleanup tasks on every node, and removes the functionality
of running docker garbage collection on every docker task run.

ping @brianhelba @cjh1 @kotfic @mgrauer 

The tradeoff here is that it moves the burden of scheduling cleanup to the deployment level. We should update our ansible roles for girder-worker to include configuration of a cronjob that occasionally runs this new entrypoint.