### PR TITLE
Update celery in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-celery==3.1.23
+celery==4.0.2
 ete3==3.0.0b35
 networkx==1.11
 Pillow==3.2.0
@@ -7,9 +7,3 @@ pytz==2016.4
 requests[security]==2.10.0
 six==1.10.0
 wsgiref==0.1.2
-
-# dependencies of celery
-amqp==1.4.9
-anyjson==0.3.3
-billiard==3.3.0.23
-kombu==3.0.34


### PR DESCRIPTION
We've deprecated Celery 3.x, but still list it explicitly in requirements.txt.  Remove explicit subpackages from requirements.txt; celery properly asks for what it needs and there is no reason we should pin versions if we don't have to.