### PR TITLE
Add an authenticated Girder Client instance to the Celery task object

### DIFF
--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -4,6 +4,7 @@ from celery import Celery, __version__
 from distutils.version import LooseVersion
 from celery.signals import (task_prerun, task_postrun,
                             task_failure, task_success, worker_ready)
+from girder_client import GirderClient
 from .utils import JobStatus
 
 
@@ -83,6 +84,11 @@ def gw_task_prerun(task=None, sender=None, task_id=None,
             raise JobSpecNotFound
 
         task.job_manager = deserialize_job_info_spec(**jobSpec)
+
+        # Trim off the /job/jobId
+        task.api_url = '/'.join(jobSpec['url'].split('/')[:-2])
+        task.girder_client = GirderClient(apiUrl=task.api_url)
+        task.girder_client.token = jobSpec['headers']['Girder-Token']
 
         _update_status(task, JobStatus.RUNNING)
 


### PR DESCRIPTION
This is more of an RFC than an actual commit.

This allows the app tasks running on workers to have access to a `girder_client` property much the same way they have access to a `job_manager`.

For example:

```
@app.task(bind=True)
def download_items(task, items):
    for item in items:
        task.girder_client.downloadItem(item['_id'], '/some/path')
```
(Side note, we should eventually unify our coding styles between Girder and Girder Worker)

Note though, it's up to the developer to pass a token with the proper permissions since by default it's a token that only has job status access.