### PR TITLE
Make docker gc opt-in, rather than opt-out.

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -156,6 +156,40 @@ If you specify an absolute path, it must start with ``/mnt/girder_worker/data/``
 will be thrown before the task is run. These conventions apply whether the path
 is specified in the ``id`` or ``path`` field.
 
+Management of Docker Containers and Images
+******************************************
+
+Docker images may be pulled when a task is run.  By default, these images are
+never removed.  Docker containers are automatically removed when the task is
+complete.
+
+As an alternative, a 'garbage collection' process can be used instead.  It can
+be enabled by modifying settings in the ``[docker]`` section of the config 
+file, which can be done using the command:
+
+.. code-block :: none
+
+  girder-worker-config set docker gc True
+
+When the ``gc`` config value is set to ``True``, containers are not removed 
+when the task ends.  Instead, periodically, any images not associated with a
+container will be removed, and then any stopped containers will be removed.
+This will free disk space associated with the images, but may remove images
+that are not directly related to Girder Worker.
+
+When garbage collection is turned on, images can be excluded from the process
+by setting ``exclude_images`` to a comma-separated list of image names.  For
+instance:
+
+.. code-block :: none
+
+  girder-worker-config set docker exclude_images dsarchive/histomicstk,rabbitmq
+
+Only containers that have been stopped longer than a certain time are removed.
+This time defaults to an hour, and can be specified as any number of seconds
+via the ``cache_timeout`` setting.
+
+
 Girder IO
 ---------
 

--- a/girder_worker/plugins/docker/__init__.py
+++ b/girder_worker/plugins/docker/__init__.py
@@ -13,6 +13,8 @@ def before_run(e):
     import executor
     if e.info['task']['mode'] == 'docker':
         executor.validate_task_outputs(e.info['task_outputs'])
+    if not _read_from_config('gc', False):
+        e.info.setdefault('kwargs', {})['_rm_container'] = True
 
 
 def _read_from_config(key, default):
@@ -32,6 +34,8 @@ def docker_gc(e):
     the same directory as this file. After that, deletes all images that are
     no longer used by any containers.
     """
+    if not _read_from_config('gc', False):
+        return
     stampfile = os.path.join(config.get('girder_worker', 'tmp_root'), '.dockergcstamp')
     if os.path.exists(stampfile) and time.time() - os.path.getmtime(stampfile) < MIN_GC_INTERVAL:
         return

--- a/girder_worker/plugins/docker/executor.py
+++ b/girder_worker/plugins/docker/executor.py
@@ -175,11 +175,15 @@ def run(task, inputs, outputs, task_inputs, task_outputs, **kwargs):
             ep_args = ['--entrypoint', task['entrypoint']]
     else:
         ep_args = []
+    if kwargs.get('_rm_container'):
+        rm_args = ['--rm']
+    else:
+        rm_args = []
 
     command = [
         'docker', 'run',
         '-v', '%s:%s' % (tempdir, DATA_VOLUME)
-    ] + task.get('docker_run_args', []) + ep_args + [image] + args
+    ] + task.get('docker_run_args', []) + rm_args + ep_args + [image] + args
 
     print('Running container: %s' % repr(command))
 

--- a/girder_worker/plugins/docker/tests/docker_test.py
+++ b/girder_worker/plugins/docker/tests/docker_test.py
@@ -30,6 +30,8 @@ processMock.configure_mock(**{
 # Monkey patch select.select in the docker task module
 def _mockSelect(r, w, x, *args, **kwargs):
     return r, w, x
+
+
 girder_worker.core.utils.select.select = _mockSelect
 
 
@@ -40,6 +42,8 @@ def _mockOsRead(fd, *args, **kwargs):
         return _out.read()
     elif fd == ERR_FD:
         return _err.read()
+
+
 girder_worker.plugins.docker.executor.os.read = _mockOsRead
 
 
@@ -196,6 +200,7 @@ class TestDockerMode(unittest.TestCase):
     def testCleanupHook(self, mockPopen):
         os.makedirs(_tmp)
         mockPopen.return_value = processMock
+        girder_worker.config.set('docker', 'gc', 'True')
         girder_worker.config.set('docker', 'cache_timeout', '123456')
         girder_worker.config.set('docker', 'exclude_images', 'test/test:latest')
 
@@ -209,6 +214,20 @@ class TestDockerMode(unittest.TestCase):
         env = mockPopen.call_args_list[0][1]['env']
         self.assertEqual(env['GRACE_PERIOD_SECONDS'], '123456')
         six.assertRegex(self, env['EXCLUDE_FROM_GC'], r'\.docker-gc-exclude$')
+
+    @mock.patch('subprocess.Popen')
+    def testCleanupHookWithoutOptIn(self, mockPopen):
+        mockPopen.return_value = processMock
+        cleanup.main()
+        self.assertEqual(mockPopen.call_count, 0)
+        # Now with explicit settings
+        mockPopen.return_value = processMock
+        girder_worker.config.set('docker', 'gc', 'False')
+        girder_worker.config.set('docker', 'cache_timeout', '123456')
+        girder_worker.config.set('docker', 'exclude_images', 'test/test:latest')
+        # Make sure docker-gc is not called during cleanup
+        cleanup.main()
+        self.assertEqual(mockPopen.call_count, 0)
 
     @mock.patch('subprocess.Popen')
     def testOutputValidation(self, mockPopen):


### PR DESCRIPTION
If you don't add a value of "gc: True" to the docker section of the config, containers are run with the --rm flag to removed themselves when done, and the docker gc script is never run (and therefore never deletes images).  If "gc: True" is specified, then containers linger after use and docker gc will clean things up with the current rules (such as cache time and exclusion lists).