### PR TITLE
Add basic packaging test

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,5 +8,5 @@ include README.rst
 include girder_worker/worker.dist.cfg
 recursive-include girder_worker/format *
 recursive-include girder_worker/plugins *
-global-exclude *.pyc *.pyo *.cmake
+global-exclude *.pyc *.pyo *.cmake worker.local.cfg
 prune girder_worker/plugins/*/tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ mock==2.0.0
 pep8-naming==0.3.3
 Sphinx==1.4.3
 sphinx-rtd-theme==0.1.9
+virtualenv==15.1.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,13 @@ if(PYTHON_STYLE_TESTS)
   add_python_flake8_test(flake8_style_tests "${PROJECT_SOURCE_DIR}/tests")
 endif()
 
+add_test(
+  NAME packaging
+  WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+  COMMAND "${PROJECT_SOURCE_DIR}/tests/packaging_test.sh"
+          "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}"
+)
+
 add_python_test(config)
 add_python_test(format)
 add_python_test(graph)

--- a/tests/packaging_test.sh
+++ b/tests/packaging_test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+source_dir="${1}"
+binary_dir="${2}"
+virtualenv ve
+. ve/bin/activate
+cd ${source_dir}
+python setup.py sdist --dist-dir ${binary_dir}
+cd ${binary_dir}
+pip install ./girder-worker-*.tar.gz
+which girder-worker
+girder-worker-config list

--- a/tests/packaging_test.sh
+++ b/tests/packaging_test.sh
@@ -4,6 +4,7 @@ set -e
 
 source_dir="${1}"
 binary_dir="${2}"
+rm -rf ve/
 virtualenv ve
 . ve/bin/activate
 cd ${source_dir}


### PR DESCRIPTION
This is a fairly basic packaging test, but it's definitely better than nothing. It does an sdist build and installs it in a virtualenv in accordance with our release docs. It doesn't go as far as starting up a message queue and worker, but it does execute some runtime worker code that at least exercises importing of the girder_worker package, which will catch an important class of packaging errors.