### PR TITLE
Allow zero-length arguments to docker.

### DIFF
--- a/girder_worker/plugins/docker/executor.py
+++ b/girder_worker/plugins/docker/executor.py
@@ -67,9 +67,10 @@ def _expand_args(args, inputs, taskInputs, tmpDir):
             else:
                 val = ''
             arg = arg.replace('$flag{%s}' % inputId, val)
+            if not arg:
+                continue
 
-        if arg:
-            newArgs.append(arg)
+        newArgs.append(arg)
 
     return newArgs
 

--- a/girder_worker/plugins/docker/executor.py
+++ b/girder_worker/plugins/docker/executor.py
@@ -54,6 +54,7 @@ def _expand_args(args, inputs, taskInputs, tmpDir):
     flagRe = re.compile(r'\$flag\{([^}]+)\}')
 
     for arg in args:
+        skip = False
         for inputId in re.findall(inputRe, arg):
             if inputId in inputs:
                 transformed = _transform_path(
@@ -68,9 +69,9 @@ def _expand_args(args, inputs, taskInputs, tmpDir):
                 val = ''
             arg = arg.replace('$flag{%s}' % inputId, val)
             if not arg:
-                continue
-
-        newArgs.append(arg)
+                skip = True
+        if not skip:
+            newArgs.append(arg)
 
     return newArgs
 


### PR DESCRIPTION
Fixed a bug where you cannot pass empty arguments to the docker container.

@zachmullen This touches a section of code you last worked on.

The problem was that we want to pass parameters to the docker of the form ['--flag', ''], and the empty string was being stripped out.