### PR TITLE
Remove wsgiref from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pymongo==3.2.2
 pytz==2016.4
 requests[security]==2.10.0
 six==1.10.0
-wsgiref==0.1.2


### PR DESCRIPTION
We don't reference this in our package anywhere, and it was causing install to fail on python3.

