### PR TITLE
Fix an issue with newer systemd requiring absolute executable paths

### DIFF
--- a/devops/ansible/roles/girder-worker/templates/daemon/girder_worker.conf.j2
+++ b/devops/ansible/roles/girder-worker/templates/daemon/girder_worker.conf.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 description "girder worker"
 
 start on started mountall

--- a/devops/ansible/roles/girder-worker/templates/daemon/girder_worker.service.j2
+++ b/devops/ansible/roles/girder-worker/templates/daemon/girder_worker.service.j2
@@ -9,12 +9,12 @@ Group={{ girder_worker_user }}
 {% if girder_worker_virtualenv is defined %}
 ExecStart={{ girder_worker_virtualenv }}/bin/girder-worker
 {% else %}
-ExecStart=girder-worker
+ExecStart={{ lookup('pipe', 'which girder-worker') }}
 {% endif %}
 {% if girder_worker_virtualenv is defined %}
 ExecStop={{ girder_worker_virtualenv }}/bin/celery multi stopwait worker
 {% else %}
-ExecStop=celery multi stopwait worker
+ExecStop={{ lookup('pipe', 'which celery') }} multi stopwait worker
 {% endif %}
 
 [Install]

--- a/devops/ansible/roles/girder-worker/templates/daemon/girder_worker.service.j2
+++ b/devops/ansible/roles/girder-worker/templates/daemon/girder_worker.service.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 [Unit]
 Description=Girder Worker Service
 After=network.target


### PR DESCRIPTION
This is templated from the user we run pip with, so this is the easiest/most effective way to get the absolute paths to these items (given we're outside of a virtualenv).

This also contains a minor change which adds the `{{ ansible_managed }}` variable (expands to "Ansible managed") to the top of our service files, this is used to indicate that people shouldn't be directly modifying these files on the systems but use Ansible instead. I plan on moving these into more of our Ansible managed infrastructure in the future.