### PR TITLE
Rename Ansible role to worker

### DIFF
--- a/devops/ansible/roles/girder-worker/README.md
+++ b/devops/ansible/roles/girder-worker/README.md
@@ -1,4 +1,4 @@
-girder.girder_worker
+girder.worker
 ====================
 An Ansible role to install [Girder Worker](https://github.com/girder/girder_worker).
 


### PR DESCRIPTION
Fixes #123 

The role (via galaxy) is now `girder.worker`. This is something we should definitely settle on now since it will be incredibly difficult to change once people start using it.