### PR TITLE
Upgrade flake8, ensure styles are consistent w/girder

### DIFF
--- a/examples/plugin_example/example_client.py
+++ b/examples/plugin_example/example_client.py
@@ -1,6 +1,7 @@
 # Import the fib task from gwexample package
 from gwexample.analyses.tasks import fibonacci
 
+
 if __name__ == '__main__':
     # Distribute the a task to calculate the fibonacci number of 25
     async_result = fibonacci.delay(26)

--- a/girder_worker/__main__.py
+++ b/girder_worker/__main__.py
@@ -55,5 +55,6 @@ def main():
 
     app.worker_main()
 
+
 if __name__ == '__main__':
     main()

--- a/girder_worker/configure.py
+++ b/girder_worker/configure.py
@@ -63,5 +63,6 @@ def main():
     elif args.cmd == 'rm':
         rm_config(args.section, args.option)
 
+
 if __name__ == '__main__':
     main()  # pragma: no cover

--- a/girder_worker/core/__init__.py
+++ b/girder_worker/core/__init__.py
@@ -44,6 +44,7 @@ def unregister_executor(name):
     """
     del _task_map[name]
 
+
 register_executor('python', python_run)
 register_executor('workflow', workflow_run)
 

--- a/girder_worker/core/format/__init__.py
+++ b/girder_worker/core/format/__init__.py
@@ -311,4 +311,5 @@ def import_default_converters():
         'table',
         'tree']])
 
+
 import_default_converters()

--- a/girder_worker/core/format/table/objectlist_to_rows.py
+++ b/girder_worker/core/format/table/objectlist_to_rows.py
@@ -15,6 +15,7 @@ def subkeys(path, obj, row):
         field_map[field] = True
         row[field] = obj
 
+
 for obj in input:
     row = {}
     subkeys([], obj, row)

--- a/girder_worker/core/format/table/rows_to_objectlist.py
+++ b/girder_worker/core/format/table/rows_to_objectlist.py
@@ -1,4 +1,3 @@
-
 def set_nested(obj, path, v):
     key = path.pop()
 
@@ -8,6 +7,7 @@ def set_nested(obj, path, v):
 
     obj[key] = {}
     set_nested(obj[key], path, v)
+
 
 output = []
 for row in input['rows']:

--- a/girder_worker/core/format/tree/nested_to_newick.py
+++ b/girder_worker/core/format/tree/nested_to_newick.py
@@ -8,6 +8,7 @@ def populate_tree(node, children):
         n = node.add_child(name=name, dist=dist)
         populate_tree(n, c.get('children', []))
 
+
 t = Tree()
 populate_tree(t, input.get('children', []))
 output = t.write(format=1)

--- a/girder_worker/core/format/tree/phyloxml_to_treestore.py
+++ b/girder_worker/core/format/tree/phyloxml_to_treestore.py
@@ -4,7 +4,7 @@ from Bio.Phylo import BaseTree
 
 
 def recursive_attr(obj):
-    """recursively parase through phyloXML data that is not a Clade"""
+    """Recursively parase through phyloXML data that is not a Clade"""
     dictionary = {}
     try:
         # if obj has subobjects, parse throuh them and insert in a dictionary
@@ -22,7 +22,7 @@ def recursive_attr(obj):
 
 
 def recursive_clade(obj, data_coll, tree_coll=None):
-    """recursively parse through phyloXML"""
+    """Recursively parse through phyloXML"""
     # instantiate variables
     clade_children = []
     tempDict = {}

--- a/girder_worker/core/specs/port.py
+++ b/girder_worker/core/specs/port.py
@@ -230,6 +230,7 @@ class Port(Spec):
             ))
         return _spec
 
+
 Port.make_property('name', 'The name of the port')
 Port.make_property('type', 'The data type of the port', 'python')
 Port.make_property('format', 'The data format of the port', 'object')

--- a/girder_worker/core/specs/spec.py
+++ b/girder_worker/core/specs/spec.py
@@ -313,4 +313,5 @@ def _update(d, u):
             d[k] = u[k]
     return d
 
+
 __all__ = ('Spec',)

--- a/girder_worker/core/specs/task.py
+++ b/girder_worker/core/specs/task.py
@@ -42,6 +42,7 @@ class TaskSpec(Spec):
 
     _serializer = str
 
+
 # add base spec properties
 TaskSpec.make_property('mode', 'The execution mode of the task', 'python')
 TaskSpec.make_property('script', 'A script or function to execute', '')
@@ -133,5 +134,6 @@ class Task(MutableMapping):
 
     def get(self, key, default=None):
         return self.__spec__.get(key, default)
+
 
 __all__ = ('TaskSpec', 'Task', 'ReadOnlyAttributeException', )

--- a/girder_worker/core/specs/workflow.py
+++ b/girder_worker/core/specs/workflow.py
@@ -21,6 +21,7 @@ class StepSpec(Spec):
     def __init__(self, *args, **kwargs):
         super(StepSpec, self).__init__(*args, **kwargs)
 
+
 StepSpec.make_property('name', 'Name of the step in the workflow')
 StepSpec.make_property('task', 'Workflow task associated with this step')
 
@@ -28,6 +29,7 @@ StepSpec.make_property('task', 'Workflow task associated with this step')
 class ConnectionSpec(Spec):
     def __init__(self, *args, **kwargs):
         super(ConnectionSpec, self).__init__(*args, **kwargs)
+
 
 ConnectionSpec.make_property(
     'name', 'Workflow external facing input or output name')
@@ -320,5 +322,6 @@ class Workflow(MutableMapping):
             del self._defaults[node_name]
         except KeyError:
             pass
+
 
 __all__ = ('Workflow', 'StepSpec', 'ConnectionSpec')

--- a/girder_worker/plugins/r/converters/tree/r_apetree_to_nested.py
+++ b/girder_worker/plugins/r/converters/tree/r_apetree_to_nested.py
@@ -47,6 +47,7 @@ def nodeNameFromIndex(index):
         return input[nodeLabelIndex][index - 1 - leafCount]
     return ''
 
+
 # loop through the nodes and create a dict for each one
 for index in range(1, totalNodes + 1):
     node = {'node_data': {}}
@@ -89,5 +90,6 @@ def nodeWeights(node, cur):
     node['node_data']['node weight'] = cur
     for c in node.get('children', []):
         nodeWeights(c, cur)
+
 
 nodeWeights(output, 0.0)

--- a/girder_worker/plugins/r/tests/arbor_test.py
+++ b/girder_worker/plugins/r/tests/arbor_test.py
@@ -66,5 +66,6 @@ class TestArbor(unittest.TestCase):
     def tearDown(self):
         os.chdir(self.prevdir)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/girder_worker/plugins/r/tests/r_test.py
+++ b/girder_worker/plugins/r/tests/r_test.py
@@ -59,5 +59,6 @@ class TestR(unittest.TestCase):
             self.function_in, inputs={'input': outputs['output']})
         self.assertEqual(outputs['output']['data'], 16)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/girder_worker/plugins/vtk/converters/tree/nested_to_vtktree.py
+++ b/girder_worker/plugins/vtk/converters/tree/nested_to_vtktree.py
@@ -20,6 +20,8 @@ def process_node(vtknode, node):
             if 'edge_data' in n:
                 dict_to_vtkrow(n['edge_data'], vtk_builder.GetEdgeData())
             process_node(vtkchild, n)
+
+
 vtk_builder.AddVertex()
 dict_to_vtkrow(input['node_data'], vtk_builder.GetVertexData())
 process_node(0, input)

--- a/girder_worker/plugins/vtk/converters/tree/vtktree_to_nested.py
+++ b/girder_worker/plugins/vtk/converters/tree/vtktree_to_nested.py
@@ -17,6 +17,7 @@ def process_node(vtknode, node):
         process_node(vtkchild, n)
         node['children'].append(n)
 
+
 node_fields = []
 for c in range(input.GetVertexData().GetNumberOfArrays()):
     node_fields.append(input.GetVertexData().GetAbstractArray(c).GetName())

--- a/girder_worker/plugins/vtk/tests/geometry_test.py
+++ b/girder_worker/plugins/vtk/tests/geometry_test.py
@@ -71,5 +71,6 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(converted.GetNumberOfCells(), 101)
         self.assertEqual(converted.GetNumberOfPoints(), 101)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/girder_worker/plugins/vtk/tests/graph_test.py
+++ b/girder_worker/plugins/vtk/tests/graph_test.py
@@ -120,5 +120,6 @@ class TestGraph(unittest.TestCase):
                           (0, 2, {'Weights': 2.0}),
                           (1, 2, {'Weights': 1.0})])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,24 @@
 coverage==4.1.0
 coveralls==1.1
-flake8==2.5.4
-flake8-docstrings==0.2.6
-flake8-quotes==0.3.0
+flake8==3.3.0
+flake8-blind-except==0.1.1
+flake8-docstrings==1.1.0
+
+# Unique to girder_worker
+flake8-quotes==0.9.0
+
+# dependencies of flake8
+mccabe==0.6.1
+pep8==1.7.0
+pyflakes==1.5.0
+
+# dependencies of flake8-docstrings
+pep257==0.7.0
+
+
 httmock==1.2.5
 lxml==3.6.0
 mock==2.0.0
-pep8-naming==0.3.3
 Sphinx==1.4.3
 sphinx-rtd-theme==0.1.9
 virtualenv==15.1.0

--- a/tests/debug_test.py
+++ b/tests/debug_test.py
@@ -12,6 +12,7 @@ def _mockTempfile():
     _tmpfiles.append(out)
     return out
 
+
 girder_worker.executors.python.tempfile.mktemp = _mockTempfile
 
 

--- a/tests/directory_test.py
+++ b/tests/directory_test.py
@@ -156,5 +156,6 @@ class TestDirectory(unittest.TestCase):
             self.assertTrue('shapefile/shapefile.cpg' in names)
             self.assertTrue('shapefile/shapefile.prj' in names)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/docstring_test.py
+++ b/tests/docstring_test.py
@@ -4,6 +4,7 @@ import doctest
 
 from base import TestCase  # noqa
 
+
 if __name__ == '__main__':
 
     error = 0

--- a/tests/flake8.cfg
+++ b/tests/flake8.cfg
@@ -7,7 +7,7 @@ show-source: True
 # Maximum cyclomatic complexity allowed
 max-complexity: 14
 format: pylint
-quotes: '
+inline-quotes: '
 # Ignore certain errors.
 #
 #   If an ignore line is not specified, the pep8 module defaults to
@@ -54,4 +54,4 @@ quotes: '
 #     N803 - Argument name should be lowercase.
 #     N806 - Variable in function should be lowercase.
 #     N812 - Lowercase imported as non lowercase.
-ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D400,D401,D402,D403,E123,E226,E241,N802,N803,N806,N812
+ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W503

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -130,5 +130,6 @@ class TestGraph(unittest.TestCase):
                           self.test_input['distances']['data'],
                           edge_match=numerical_edge_match('distance', 1)))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integer_list_test.py
+++ b/tests/integer_list_test.py
@@ -78,5 +78,6 @@ class TestIntegerList(unittest.TestCase):
                 'c': {'format': 'integer_list'}
             })
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integer_test.py
+++ b/tests/integer_test.py
@@ -76,5 +76,6 @@ class TestInteger(unittest.TestCase):
                 'c': {'format': 'integer'}
             })
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/number_list_test.py
+++ b/tests/number_list_test.py
@@ -90,5 +90,6 @@ class TestNumberList(unittest.TestCase):
                 'c': {'format': 'number_list'}
             })
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/number_test.py
+++ b/tests/number_test.py
@@ -89,5 +89,6 @@ class TestNumber(unittest.TestCase):
                 'c': {'format': 'number'}
             })
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/string_list_test.py
+++ b/tests/string_list_test.py
@@ -77,5 +77,6 @@ class TestStringList(unittest.TestCase):
                 'c': {'format': 'string_list'}
             })
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -81,5 +81,6 @@ class TestNumber(unittest.TestCase):
         self.assertEqual(outputs['c']['data'], u'hi, there')
         self.assertIsInstance(outputs['c']['data'], unicode)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/write_script_test.py
+++ b/tests/write_script_test.py
@@ -13,6 +13,7 @@ def _mockTempfile():
     _tmpfiles.append(out)
     return out
 
+
 girder_worker.core.executors.python.tempfile.mktemp = _mockTempfile
 
 


### PR DESCRIPTION
This still requires inline quotes to be single quote ('),  which is
more restrictive than girder. Otherwise flake8/pep versions and
ignored fields are identical with girder master.

Many files change here to meet E305