### PR TITLE
Use the latest image of busybox.

### DIFF
--- a/girder_worker/plugins/docker/__init__.py
+++ b/girder_worker/plugins/docker/__init__.py
@@ -103,7 +103,7 @@ def task_cleanup(e):
         args = ['chmod', '-R', 'a+rw', DATA_VOLUME]
 
         try:
-            client.containers.run('busybox', args, **config)
+            client.containers.run('busybox:latest', args, **config)
         except DockerException as dex:
             logger.error('Error setting perms on docker tempdir %s.' % tmpdir)
             logger.exception(dex)

--- a/girder_worker/plugins/docker/tests/docker_test.py
+++ b/girder_worker/plugins/docker/tests/docker_test.py
@@ -185,7 +185,7 @@ class TestDockerMode(unittest.TestCase):
             self.assertEqual(args[1][-1], '--bar')
 
             args, kwargs = run2
-            self.assertEqual(args[0], 'busybox')
+            self.assertEqual(args[0], 'busybox:latest')
 
             self.assertTrue(kwargs['remove'])
             six.assertRegex(self, kwargs['volumes'].keys()[0], _tmp + '/.*')
@@ -238,8 +238,6 @@ class TestDockerMode(unittest.TestCase):
             self.assertEqual(docker_client_mock.containers.run.call_count, 2)
             args = docker_client_mock.containers.run.call_args_list[0][0]
             self.assertEqual(args[0], 'test/test:latest')
-            #             self.assertEqual(mockPopen.call_count, 3)
-#             cmd2 = mockPopen.call_args_list[1][1]['args']
             self.assertEqual(args[1], [
                 '-f',
                 '/mnt/girder_worker/data/file.txt',


### PR DESCRIPTION
Without this, the docker python client will pull *all* versions of busybox.

See issue #131.