### PR TITLE
Use the appropriate docker server version.

### DIFF
--- a/girder_worker/plugins/docker/__init__.py
+++ b/girder_worker/plugins/docker/__init__.py
@@ -88,7 +88,7 @@ def task_cleanup(e):
     from .executor import DATA_VOLUME
     if e.info['task']['mode'] == 'docker' and '_tempdir' in e.info['kwargs']:
         tmpdir = e.info['kwargs']['_tempdir']
-        client = docker.from_env()
+        client = docker.from_env(version='auto')
         config = {
             'tty': True,
             'volumes': {

--- a/girder_worker/plugins/docker/executor.py
+++ b/girder_worker/plugins/docker/executor.py
@@ -16,7 +16,7 @@ def _pull_image(image):
     """
     Pulls the specified Docker image onto this worker.
     """
-    client = docker.from_env()
+    client = docker.from_env(version='auto')
     try:
         client.images.pull(image)
     except DockerException as dex:
@@ -163,7 +163,7 @@ def _setup_pipes(task_inputs, inputs, task_outputs, outputs, tempdir, job_mgr, p
 
 def _run_container(image, args, **kwargs):
     # TODO we could allow configuration of non default socket
-    client = docker.from_env()
+    client = docker.from_env(version='auto')
 
     logger.info('Running container: image: %s args: %s kwargs: %s' % (image, args, kwargs))
     try:


### PR DESCRIPTION
Weirdly, the python docker client defaults to insisting on a specific docker server version.  If the server is older than the client, this fails.  By setting the version to auto, it asks the server what protocol version to use and then works.