### PR TITLE
Fix Dockerfile to properly support environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,17 @@ COPY girder_worker /girder_worker/girder_worker
 RUN pip install -r requirements.txt -e .
 
 RUN useradd -D --shell=/bin/bash && useradd -m worker
-RUN sed -i girder_worker/worker.local.cfg \
-   -e '/^broker/ s/guest@localhost/%(RABBITMQ_USER)s:%(RABBITMQ_PASS)s@%(RABBITMQ_HOST)s/'
+
+RUN cp girder_worker/worker.dist.cfg girder_worker/worker.local.cfg && \
+    sed -i girder_worker/worker.local.cfg \
+    -e '/^broker/ s/guest@localhost/%(RABBITMQ_USER)s:%(RABBITMQ_PASS)s@%(RABBITMQ_HOST)s/'
+
 RUN girder-worker-config set girder_worker tmp_root /tmp
+
+COPY devops/docker-entrypoint.sh /girder_worker/docker-entrypoint.sh
+
+RUN chown -R worker:worker /girder_worker
 
 USER worker
 
-ENTRYPOINT ["python", "-m", "girder_worker"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/devops/docker-entrypoint.sh
+++ b/devops/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/usr/bin/env RABBITMQ_USER=${RABBITMQ_USER:-guest} \
+             RABBITMQ_PASS=${RABBITMQ_PASS:-guest} \
+             RABBITMQ_HOST=${RABBITMQ_HOST:-localhost} \
+             python -m girder_worker

--- a/girder_worker/__init__.py
+++ b/girder_worker/__init__.py
@@ -9,7 +9,14 @@ __license__ = 'Apache 2.0'
 PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 # Read the configuration files
 _cfgs = ('worker.dist.cfg', 'worker.local.cfg')
-config = SafeConfigParser(os.environ)
+
+
+config = SafeConfigParser({
+    'RABBITMQ_USER': os.environ.get('RABBITMQ_USER', 'guest'),
+    'RABBITMQ_PASS': os.environ.get('RABBITMQ_PASS', 'guest'),
+    'RABBITMQ_HOST': os.environ.get('RABBITMQ_HOST', 'localhost')
+})
+
 config.read([os.path.join(PACKAGE_DIR, f) for f in _cfgs])
 
 # Create and configure our logger

--- a/girder_worker/__init__.py
+++ b/girder_worker/__init__.py
@@ -9,7 +9,7 @@ __license__ = 'Apache 2.0'
 PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 # Read the configuration files
 _cfgs = ('worker.dist.cfg', 'worker.local.cfg')
-config = SafeConfigParser()
+config = SafeConfigParser(os.environ)
 config.read([os.path.join(PACKAGE_DIR, f) for f in _cfgs])
 
 # Create and configure our logger


### PR DESCRIPTION
currently the Dockerfile does not support default arguments for ```RABBITMQ_USER```, ```RABBITMQ_PASS``` or ```RABBITMQ_HOST```. This ensures that the container runs even if it doesn't have those environment variables set. 