### PR TITLE
Refactor custom job options

### DIFF
--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -47,7 +47,7 @@ class Task(celery.Task):
     """Girder Worker Task object"""
 
     _girder_job_title = '<unnamed job>'
-    _girder_job_type = None
+    _girder_job_type = 'celery'
     _girder_job_public = False
     _girder_job_handler = 'celery_handler'
     _girder_job_other_fields = {}
@@ -77,7 +77,15 @@ class Task(celery.Task):
 
         # Pass girder related job information through to
         # the signals by adding this information to options['headers']
-        headers = {}
+        # This sets defaults for reserved_options based on the class defaults,
+        # or values defined by the girder_job() dectorator
+        headers = {
+            'girder_job_title': self._girder_job_title,
+            'girder_job_type': self._girder_job_type,
+            'girder_job_public': self._girder_job_public,
+            'girder_job_handler': self._girder_job_handler,
+            'girder_job_other_fields': self._girder_job_other_fields,
+        }
 
         # Certain keys may show up in either kwargs (e.g. via .delay(girder_token='foo')
         # or in options (e.g.  .apply_async(args=(), kwargs={}, girder_token='foo')

--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -46,13 +46,27 @@ class GirderAsyncResult(AsyncResult):
 class Task(celery.Task):
     """Girder Worker Task object"""
 
-    _girder_job_title = None
+    _girder_job_title = '<unnamed job>'
     _girder_job_type = None
     _girder_job_public = False
     _girder_job_handler = 'celery_handler'
     _girder_job_other_fields = {}
 
-    special_headers = ['girder_token', 'girder_user']
+    # These keys will be removed from apply_async's kwargs or options and
+    # transfered into the headers of the message.
+    special_headers = [
+        'girder_client_token',
+        'girder_api_url']
+
+    # These keys will be available in the 'properties' dictionary inside
+    # girder_before_task_publish() but will not be passed along in the message
+    special_options = [
+        'girder_user',
+        'girder_job_title',
+        'girder_job_type',
+        'girder_job_public',
+        'girder_job_handler',
+        'girder_job_other_fields']
 
     def AsyncResult(self, task_id, **kwargs):
         return GirderAsyncResult(task_id, backend=self.backend,
@@ -69,17 +83,11 @@ class Task(celery.Task):
         # or in options (e.g.  .apply_async(args=(), kwargs={}, girder_token='foo')
         # For those special headers,  pop them out of kwargs or options and put them
         # in headers so they can be picked up by the before_task_publish signal.
-        for key in self.special_headers:
+        for key in self.special_headers + self.special_options:
             if kwargs is not None and key in kwargs:
                 headers[key] = kwargs.pop(key)
             if key in options:
                 headers[key] = options.pop(key)
-
-        headers['girder_job_title'] = self._girder_job_title
-        headers['girder_job_type'] = self._girder_job_type
-        headers['girder_job_public'] = self._girder_job_public
-        headers['girder_job_handler'] = self._girder_job_handler
-        headers['girder_job_other_fields'] = self._girder_job_other_fields
 
         if 'headers' in options:
             options['headers'].update(headers)
@@ -118,34 +126,53 @@ def girder_before_task_publish(sender=None, body=None, exchange=None,
             job_model = ModelImporter.model('job', 'jobs')
 
             user = headers.pop('girder_user', getCurrentUser())
-            token = headers.pop('girder_token', None)
-
             task_args, task_kwargs = body[0], body[1]
 
             job = job_model.createJob(
-                **{'title': headers.get('girder_job_title', Task._girder_job_title),
-                   'type': headers.get('girder_job_type', Task._girder_job_type),
-                   'handler': headers.get('girder_job_handler', Task._girder_job_handler),
-                   'public': headers.get('girder_job_public', Task._girder_job_public),
+                **{'title': headers.pop('girder_job_title', Task._girder_job_title),
+                   'type': headers.pop('girder_job_type', Task._girder_job_type),
+                   'handler': headers.pop('girder_job_handler', Task._girder_job_handler),
+                   'public': headers.pop('girder_job_public', Task._girder_job_public),
                    'user': user,
                    'args': task_args,
                    'kwargs': task_kwargs,
                    'otherFields': dict(celeryTaskId=headers['id'],
-                                       **headers.get('girder_job_other_fields',
+                                       **headers.pop('girder_job_other_fields',
                                                      Task._girder_job_other_fields))})
-            # If we don't have a token from girder_token kwarg,  use
-            # the job token instead. Otherwise no token
-            if token is None:
-                token = job.get('token', None)
 
-            headers['jobInfoSpec'] = utils.jobInfoSpec(job, token)
-            headers['apiUrl'] = utils.getWorkerApiUrl()
+            headers['jobInfoSpec'] = utils.jobInfoSpec(job)
 
         except ImportError:
             # TODO: Check for self.job_manager to see if we have
             #       tokens etc to contact girder and create a job model
             #       we may be in a chain or a chord or some-such
             pass
+
+    if 'girder_api_url' not in headers:
+        try:
+            from girder.plugins.worker import utils
+            headers['girder_api_url'] = utils.getWorkerApiUrl()
+        except ImportError:
+            # TODO: handle situation where girder_worker is producing the message
+            #       Note - this may not come up at all depending on how we pass
+            #       girder_api_url through to the next task (e.g. in the context
+            #       of chaining events)
+            pass
+
+    if 'girder_client_token' not in headers:
+        try:
+            from girder.utility.model_importer import ModelImporter
+            headers['girder_client_token'] = ModelImporter.model('token').createToken()
+        except ImportError:
+            # TODO: handle situation where girder_worker is producing the message
+            #       Note - this may not come up at all depending on how we pass
+            #       girder_token through to the next task (e.g. in the context
+            #       of chaining events)
+            pass
+
+    # Finally,  remove all special_options from headers
+    for key in Task.special_options:
+        headers.pop(key)
 
 
 @worker_ready.connect

--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -10,6 +10,7 @@ from celery.result import AsyncResult
 from six.moves import configparser
 import sys
 from .utils import JobStatus
+from girder_client import GirderClient
 
 
 class GirderAsyncResult(AsyncResult):
@@ -234,6 +235,12 @@ def gw_task_prerun(task=None, sender=None, task_id=None,
     except JobSpecNotFound:
         task.job_manager = None
         print('Warning: No jobInfoSpec. Setting job_manager to None.')
+
+    try:
+        task.girder_client = GirderClient(apiUrl=task.request.girder_api_url)
+        task.girder_client.token = task.request.girder_client_token
+    except AttributeError:
+        task.girder_client = None
 
 
 @task_success.connect

--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -54,13 +54,13 @@ class Task(celery.Task):
 
     # These keys will be removed from apply_async's kwargs or options and
     # transfered into the headers of the message.
-    special_headers = [
+    reserved_headers = [
         'girder_client_token',
         'girder_api_url']
 
     # These keys will be available in the 'properties' dictionary inside
     # girder_before_task_publish() but will not be passed along in the message
-    special_options = [
+    reserved_options = [
         'girder_user',
         'girder_job_title',
         'girder_job_type',
@@ -83,7 +83,7 @@ class Task(celery.Task):
         # or in options (e.g.  .apply_async(args=(), kwargs={}, girder_token='foo')
         # For those special headers,  pop them out of kwargs or options and put them
         # in headers so they can be picked up by the before_task_publish signal.
-        for key in self.special_headers + self.special_options:
+        for key in self.reserved_headers + self.reserved_options:
             if kwargs is not None and key in kwargs:
                 headers[key] = kwargs.pop(key)
             if key in options:
@@ -170,9 +170,9 @@ def girder_before_task_publish(sender=None, body=None, exchange=None,
             #       of chaining events)
             pass
 
-    # Finally,  remove all special_options from headers
-    for key in Task.special_options:
-        headers.pop(key)
+    # Finally,  remove all reserved_options from headers
+    for key in Task.reserved_options:
+        headers.pop(key, None)
 
 
 @worker_ready.connect

--- a/girder_worker/utils.py
+++ b/girder_worker/utils.py
@@ -3,7 +3,7 @@ import time
 import sys
 
 
-def girder_job(title=None, type=None, public=False,
+def girder_job(title=None, type='celery', public=False,
                handler='celery_handler', otherFields=None):
     """Decorator that populates a girder_worker celery task with
     girder's job metadata.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytz==2016.4
 requests[security]==2.10.0
 six==1.10.0
 stevedore==1.24.0
+girder-client==2.2.1

--- a/tests/integration/HACKING.md
+++ b/tests/integration/HACKING.md
@@ -1,12 +1,16 @@
+*Note: This documentation is a work in progress, if you find problems with it's construction or it's content.  Please file an issue!*
+
 # What is this all about?
-In this documentation we will descend through increasingly detailed descriptions of Girder Worker and it's relationship to [Celery](http://www.celeryproject.org/), ending up with descriptions of how you can use Girder Worker to run remote, asynchronous, tasks in your own extensions to Girder.
+In this documentation we will descend through increasingly detailed descriptions of Girder Worker and its relationship to [Celery](http://www.celeryproject.org/), ending up with descriptions of how you can use Girder Worker to run remote asynchronous tasks.
 
 ## 10,000 foot view
 Girder Worker is an application that wraps Celery; it relies on Celery's distributed task execution mechanisms to do work, while reflecting task state and logging information back into [Girder](https://girder.readthedocs.io/) for visualization, debugging and management. Girder Worker is designed to receive and execute tasks that have been produced by Girder. Messages that encode what tasks and task arguments are passed from Girder to Girder Worker via a separate service called a [broker](http://docs.celeryproject.org/en/latest/getting-started/brokers/). In many common setups this broker is [RabbitMQ](https://www.rabbitmq.com/). 
 
 Girder Worker runs in a separate process from Girder. It may run on the same physical machine as Girder,  or may be run on one or more separate machines. At a low level, RabbitMQ brokers the communication between Girder and Girder Worker.  If Girder and Girder Worker are running on separate machines, both machines must be able to connect to the server running RabbitMQ.
 
-Assuming you have configured girder-worker to connect to the RabbitMQ service, running Girder Worker is easy. From a command line simply run:
+Girder Worker's configuration is managed by an INI style configuration file located in ```girder_worker/worker.dist.cfg```. This file is version controlled and should not be directly modified.  To customize configurations copy the ```worker.dist.cfg``` to ```worker.local.cfg``` and make your modifications there. There are several commented configurations available in the configuration file. The most important is the ```broker``` config under the ```[celery]``` section. This is how Girder Worker connects to RabbitMQ and should follow Celery's [broker_url](http://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-url) syntax. 
+
+Assuming you have configured Girder Worker to connect to the RabbitMQ service, running Girder Worker is easy. From a command line simply run:
 
 ```python
 $> girder-worker
@@ -38,9 +42,9 @@ Vocabulary can be an area of confusion when dealing with these systems. In an at
 
 The term **Job** will always refer to the concept of a Girder [Job](http://girder.readthedocs.io/en/latest/plugins.html#jobs). Jobs are displayed on the Job's panel in Girder. They are represented in the database as [Job Models](https://github.com/girder/girder/blob/master/plugins/jobs/server/models/job.py). Girder Job's have various states and notification streams, and can be scheduled to execute on Girder Worker. 
 
-The term **Task** on the other hand will always refer to the Celery concept of a [Task](http://docs.celeryproject.org/en/latest/userguide/tasks.html). Tasks are typified by decorated python functions that can be scheduled to run on Girder Worker via the Celery [task calling api](http://docs.celeryproject.org/en/latest/userguide/calling.html). They are not persisted in any database but exist as python objects which are imported from a package. 
+The term **Task** on the other hand will always refer to the Celery concept of a [Task](http://docs.celeryproject.org/en/latest/userguide/tasks.html). Tasks are typified by decorated python functions that can be scheduled to run on Girder Worker via the Celery [task calling api](http://docs.celeryproject.org/en/latest/userguide/calling.html). Unlike Jobs, Tasks are not stored in a database. Tasks are python functions, defined in a python module, that have been decorated by the Girder Worker's ```@app.task``` decorator. This means they do not exist until they are imported from the module in which they are defined. 
 
-Related to tasks are [messages](http://docs.celeryproject.org/en/latest/internals/protocol.html). A **Message** is the serialized task object that is placed on a broker's queue. By default, serialization is achieved by creating a dictionary of the function name, the arguments, keyword arguments and message metadata and then serializing this dictionary as a JSON string. Usually message serialization and queuing happens on the Girder side,  this is called *producing* a message, and in this case you might describe Girder as a **Producer** (Note that it is possible for other things to produce messages including Girder Worker. This usually takes place when functions are chained together using celery's [canvas](https://github.com/OpenGeoscience/ktile/pull/21#issuecomment-313379362) features). In our case, Girder Worker usually pulls messages off of the queue, deserializes them back into Celery Task objects and then applies those task objects to the arguments and keyword arguments encoded in the message.  This is usually referred to as *consuming* a message and makes Girder Worker a **Consumer**.
+Related to tasks are [messages](http://docs.celeryproject.org/en/latest/internals/protocol.html). A **Message** is the serialized task object that is placed on a broker's queue. By default, serialization is achieved by creating a dictionary of the function name, the arguments, keyword arguments and message metadata and then serializing this dictionary as a JSON string. Commonly message serialization and queuing happens on the Girder side,  this is called *producing* a message, and in this case you might describe Girder as a **Producer** (Note that it is possible for other things to produce messages including Girder Worker. An example of when this would happen is using celery's [canvas](https://github.com/OpenGeoscience/ktile/pull/21#issuecomment-313379362) features). In our case, Girder Worker usually pulls messages off of the queue, deserializes them back into Celery Task objects and then applies those task objects to the arguments and keyword arguments encoded in the message.  This is referred to as *consuming* a message and makes Girder Worker a **Consumer**.
 
 To Recap:
 
@@ -52,10 +56,12 @@ To Recap:
 
 ## 1,000 foot view
 
-There are currently two ways of using Girder to produce messages for consumption by Girder Worker. The first, called the "Traditional" method is to use the [Worker](http://girder.readthedocs.io/en/latest/plugins.html#remote-worker) plugin to create and schedule a Girder job. The worker job handler then produces a celery message and places it on the queue for consumption by Girder Worker. This is the *Job creates Task* approach. The second (and preferred) approach is the "Celery" way. In this approach a celery task object is imported from a package and called using the standard celery API (e.g. with the ```.delay(...)``` or the ```.apply_async(...)``` methods). As long as the task object inherits from custom task class ```girder_worker.app.Task``` then this approach will create a Girder Job automatically. This is the *Task creates Job* approach. 
+There are currently two ways of using Girder to produce messages for consumption by Girder Worker. The first, called the "Traditional" method is to use the [Worker](http://girder.readthedocs.io/en/latest/plugins.html#remote-worker) plugin to create and schedule a Girder job. The worker job handler then produces a celery message and places it on the queue for consumption by Girder Worker. This is the *Job creates Task* approach (though more accurately it is the "Job creates message which is consumed by Girder Worker where the message is applied to as Task). 
+
+The traditional method is historically how Girder Worker was used going all the way back to its progenitor [Romanesco](https://github.com/Kitware/romanesco). It is consistent Girder's approach to Jobs; it attempts to abstract the notion of a job from the mechanism that schedules that job. For simple cases this is sufficient but it limits the power of individual schedulers to the common semantics of the Job. Because of this the "Celery" way is also supported. The second (and preferred) approach is the Celery way. In this approach a celery task object is imported from a package and called using the standard celery API (e.g. with the ```.delay(...)``` or the ```.apply_async(...)``` methods). As long as the task object inherits from custom task class ```girder_worker.app.Task``` then this approach will create a Girder Job automatically. This is the *Task creates Job* approach. 
 
 ### An Example Task
-To illustrate the differences between the traditional and celery methods of executing remote tasks we'll use a dummy task ```fibonacci``` that inefficiently calculates the [Fibonacci](https://en.wikipedia.org/wiki/Fibonacci_number) number of an input parameter ```n```:
+To illustrate the differences between the traditional and celery methods of executing remote tasks we'll use an example task ```fibonacci``` that inefficiently calculates the [Fibonacci](https://en.wikipedia.org/wiki/Fibonacci_number) number of an input parameter ```n```:
 
 ```python
 from girder_worker.app import app
@@ -67,7 +73,7 @@ def fibonacci(n, **kwargs):
     return fibonacci(n-1) + fibonacci(n-2)
 ```
 
-Tasks such as this must be placed be available in a package installed in the Girder Worker environment. For our purposes we will assume this task can be imported from ```my_custom_package.tasks```
+Tasks such as this must be placed in a package that is Python importable. For our purposes we will assume this task can be imported from ```my_custom_package.tasks```
 
 For Example:
 ```python
@@ -78,7 +84,7 @@ from my_custom_package.tasks import fibonacci
 
 ## The Traditional Method
 
-To run the fibonacci task remotely through Girder Worker using the traditional method,  we must create a Girder job, save that job, and schedule it using the Worker plugin. To produce a Celery message using the traditional method two conditions must be met. (1) the Worker plugin must be enabled from the admin plugins panel and (2) the ```handler``` key word argument must be set to the string ```worker_handler```. 
+To run the fibonacci task remotely through Girder Worker using the traditional method,  we must create a Girder job, save that job, and schedule it using the Worker plugin. To produce a Celery message using the traditional method two conditions must be met. (1) the Worker plugin must be enabled from the admin plugins panel and (2) the ```handler``` key word argument must be set to the string ```worker_handler``` in the ```createJob(...)``` function. 
 
 The following code illustrates how to create, save, and schedule the fibonacci job:
 
@@ -110,12 +116,20 @@ return job
 
 *This is code you might see in a REST request handler that is dedicated to launching fibonacci jobs. See the [Jobs](http://girder.readthedocs.io/en/latest/plugins.html?highlight=schedule#jobs) documentation for more information about creating, saving and scheduling jobs.*
 
-In the above code we get the job model singleton which uses a [factory](https://en.wikipedia.org/wiki/Factory_method_pattern) method ```createJob(...)``` to create the job. In our example you should replace the ```title``` and ```type``` keyword arguments with values that make sense for your purposes. Note that ```type``` is a arbitrary string used to categorize jobs, it has no inherent semantic value. ```user``` should be an instance of a user model,  the job will 'belong' to this user. ```public``` effects whether or not only the ```user``` can see the job or not. ```args``` Is a list of arguments to apply the consumer-side task object too (In our example ```n``` in ```my_custom_package.tasks.fibonacci``` will be 20). ```kwargs``` is a list of keyword arguments to apply the consumer-side task object too (In our example none). ```handler``` in our case *must be* ```"worker_handler"``` or the Worker plugin handler will not execute and the Celery message will not be produced. Finally ```otherFields``` is a dictionary of fields that are specific to Worker plugin job models. 
+The params of the job model singleton ```createJob``` are: 
++ *title* which sets the display title of the Job
++ *type*  which sets the Job type (Note that ```type``` is a arbitrary string used to categorize jobs, it has no inherent semantic value).
++ *user* which should be an instance of a user model. the job will belong to this user. 
++ *public* which affects whether or not anonymous users can see the job or not. 
++ *args* which is a list of arguments to apply the consumer-side task object to (In our example ```n``` in ```my_custom_package.tasks.fibonacci``` will be 20). 
++ *kwargs* which is a list of keyword arguments to which the consumer-side task object is applied (In our example there are none). 
++ *handler* which *must be* ```"worker_handler"``` or the Worker plugin handler will not execute and the Celery message will not be produced.
++ *otherFields* which is a dictionary of fields that are specific to Worker plugin job models. 
 
 Currently the Worker plugin supports two ```otherFields```:
 
 + **celeryTaskName** should be the name of the task object. This is almost always the python importable path to the task as a string (unless you have specifically set the [name](http://docs.celeryproject.org/en/latest/userguide/tasks.html#names) when decorating the function). In our example this is the string "my_custom_package.tasks.fibonacci". If you do not specify a ```celeryTaskName``` in ```otherFields``` it will use "girder_worker.run" by default.
-+ **celeryQueue** allows you to place the produces message on a different RabbitMQ queue than the default ```celery``` queue.
++ **celeryQueue** allows you to place the produced message on a different RabbitMQ queue than the default ```celery``` queue.
 
 For the final part of our example we use the jobModel singleton to save the job to the database and then schedule the job to execute. 
 
@@ -128,7 +142,7 @@ The one advantage of the traditional approach is that it does not require the pa
 
 ## The Celery Method
 
-The Celery method for producing messages from Girder to be consumed by Girder Worker is the preferred method. This requires installing the package that contains the task (e.g. ```my_custom_package```) in the girder environment. Once this is complete the following code will produce (generated and enqueue) a message and, as a side-effect, it will create a Girder Job. 
+The Celery method for producing messages from Girder to be consumed by Girder Worker is the preferred method. This requires installing the package that contains the task (e.g. ```my_custom_package```) in the girder environment. Once this is complete the following code will produce (generate and enqueue) a message and, as a side-effect, it will create a Girder Job. 
 
 ```python
 # Import the Celery Task object
@@ -142,17 +156,17 @@ async_result = fibonacci.delay(20)
 return async_result.job
 ```
 
-*Note that,  like the code for the Traditional method, this is code you might see in a REST request handler that is dedicated to launching fibonacci jobs. See the [Celery Task API]( documentation for more information about creating, saving and scheduling jobs.) for more information about how to call and configure celery tasks.*
+*Note that,  like the code for the Traditional method, this is code you might see in a REST request handler that is dedicated to launching fibonacci jobs. See the [Celery Task API](http://docs.celeryproject.org/en/latest/userguide/calling.html) for more information about how to call and configure celery tasks.*
 
-The previous code should look familiar to anyone who has used a Celery task before. The only surprising part should be referencing ```async_result.job```. Girder Worker tasks inherit from a custom base task. This base task returns a subclassed version of ```celery.result.AsyncResult``` that includes a ```job``` property.  This ```job``` attribute will return the Girder Job model that was created as a side effect of generating and en-queuing the message.  
+The previous code should look familiar to anyone who has used a Celery task before. We import the fibonacci task object from the ```my_custom_package.tasks``` module and then call ```.delay(20)```. This will generate a message and consumer-side will apply the fibonacci function to the number 20 (returning 6765). The only surprising part should be referencing ```async_result.job```. Girder Worker tasks inherit from a custom base task. This base task creates the Girder Job and returns a subclassed version of ```celery.result.AsyncResult``` that includes a ```job``` property.  This ```job``` attribute will return the Girder Job model that was created as a side effect of generating and en-queuing the message.  
 
 
 ### Notes about the Celery Method
 
-While the Celery method is much more terse than the Traditional method,  the astute reader will recognize that it does not (as illustrated) provide the ability to modify the properties of the Girder job that is generated. In fact, using the fibonacci task introduced previously,  with the Celery method will produce a job in the Girder Job panel with the title "\<unnammed job\>". To remedy this situation a series of "special" or "reserved" Girder Worker specific keywords may be passed to any of the Celery Task API methods.  These keywords allow per-task invocation modification of the generated girder Job. They are:
+While the Celery method is much more terse than the Traditional method,  the astute reader will recognize that it does not (as illustrated) provide the ability to modify the properties of the Girder Job that is generated. In fact, using the fibonacci task introduced previously,  with the Celery method will produce a job in the Girder Job panel with the title "\<unnammed job\>". To remedy this situation a series of reserved Girder Worker specific keywords may be passed to any of the Celery Task API methods.  These keywords allow per-task invocation modification of the generated Girder Job. They are:
 
 + **girder_job_title** This changes the job title, by default (e.g if girder\_job\_title is omitted) it is "\<unnamed job\>".
-+ **girder_job_type** This changes the job type, by default it is "celery"
++ **girder_job_type** This changes the job type, by default it is "celery" (Note that ```girder_job_type``` is a arbitrary string used to categorize jobs, it has no inherent semantic value).
 + **girder_job_public** This changes the public status of the job, by default it is False
 + **girder_job_handler** This changes the job handler,  by default it is "celery_handler" (Note: do not change this unless you are sure you know what you are doing).
 + **girder_job_other_fields** This field allows you to set additional handler specific fields on the Job.  Currently the "celery_handler" has no additional standard fields. This could however be used to extend the job model data to suit application specific needs.
@@ -168,28 +182,28 @@ from my_custom_package.tasks import fibonacci
 
 # Generate a message and place it on the queue
 async_result = fibonacci.delay(20, 
-    girder_job_title='Fibonacci Job',
+	girder_job_title='Fibonacci Job',
 	girder_job_type='my_custom_type',
 	girder_job_public=True,
 	girder_job_other_fields= {
-	    'some_custom_field': 'some_custom_value'
+		'some_custom_field': 'some_custom_value'
 	})
 
 # Return the Girder Job
 return async_result.job
 ```
 
-These keyword arguments may also be passed as keyword arguments (or 'options') to the ```.apply_async(...)```, ```.s(...)``` and ```.signature(...)``` methods:
+These keyword arguments may also be passed to the ```.apply_async(...)```, ```.s(...)``` and ```.signature(...)``` methods:
 
 ```python
 async_result = fibonacci.apply_async(
 	args=(20,), 
 	kwargs={}, 
-    girder_job_title='Fibonacci Job',
+	girder_job_title='Fibonacci Job',
 	girder_job_type='my_custom_type',
 	girder_job_public=True,
 	girder_job_other_fields= {
-	    'some_custom_field': 'some_custom_value'
+		'some_custom_field': 'some_custom_value'
 	})
 
 ```
@@ -198,13 +212,13 @@ Or equally:
 
 ```python
 sig = fibonacci.s(20, 
-    girder_job_title='Fibonacci Job',
+	girder_job_title='Fibonacci Job',
 	girder_job_type='my_custom_type',
 	girder_job_public=True,
 	girder_job_other_fields= {
-	    'some_custom_field': 'some_custom_value'
+		'some_custom_field': 'some_custom_value'
 	})
-	
+
 async_result = sig.delay()
 
 return async_result.job
@@ -221,27 +235,26 @@ from girder_worker.app import app
 
 
 @girder_job(title='Fibonacci Job',
-            type='my_custom_type',
-			public=True, otherFields={
-			    'some_custom_field': 'some_custom_value'
-			})
+	type='my_custom_type',
+	public=True, otherFields={
+	'some_custom_field': 'some_custom_value'})
 @app.task
 def fibonacci(n, **kwargs):
-    if n == 1 or n == 2:
-        return 1
-    return fibonacci(n-1) + fibonacci(n-2)
+	if n == 1 or n == 2:
+		return 1
+	return fibonacci(n-1) + fibonacci(n-2)
 
 ```
 
-Decorated like so, the ```fibonacci.delay(...)``` function will act as though the corresponding keyword arguments were passed into the function. Defaults defined with ```@girder_job``` will be over-ridden by invocation specific keyword arguments.
+Decorated like so, the ```fibonacci.delay(...)``` function will act as though the corresponding keyword arguments were passed into the function. Defaults defined with ```@girder_job``` will be over-ridden by invocation specific keyword arguments. Note that the ```girder_job``` decorator must be placed *after* the ```app.task``` decorator. 
 
 #### Girder Client
-Two other options are also available as reserved keyword arguments. These provide the information necessary for tasks being executed on a Consumer to talk back to girder:
+Each task that is running consumer-side has access to a Girder Client object for talking back to the deployment of Girder that spawned that task. By default this client has the permissions of an unauthenticated user and expects Girder to be running at localhost on port 8080.  This can be changed by using the following reserved keyword arguments:
 
 + **girder_client_token**
 + **girder_api_url**
 
-These are **not** used in Girder job creation,  but instead provide each executing, consumer side, task with access to an instantiated [GirderClient](http://girder.readthedocs.io/en/latest/python-client.html#the-python-client-library). This client can be used to perform arbitrary RESTful calls against the girder instance. The URL location of the girder API is specified with ```girder_api_url``` keyword argument. The default ```girder_api_url``` will be the return value of ```girder.plugins.worker.utils.getWorkerApiUrl()```. The client will be instantiated with the ```girder_client_token``` as its authentication mechanism. This means the consumer-side client will have permissions that are consistent with the scopes applied to the token. The default ```girder_client_token``` is ```None```.
+These are **not** used in Girder job creation,  but instead provide each executing, consumer side, task with access to an instantiated [GirderClient](http://girder.readthedocs.io/en/latest/python-client.html#the-python-client-library). This client can be used to perform arbitrary RESTful calls against the girder deployment. The URL location of the girder API is specified with ```girder_api_url``` keyword argument. The default ```girder_api_url``` will be the return value of ```girder.plugins.worker.utils.getWorkerApiUrl()```. The client will be instantiated with the ```girder_client_token``` as its authentication mechanism. This means the consumer-side client will have permissions that are consistent with the scopes applied to the token. The default ```girder_client_token``` is ```None```.
 
 An example:
 
@@ -255,16 +268,16 @@ from girder.utility.model_importer import ModelImporter
 @access.token
 @filtermodel(model='job', plugin='jobs')
 @describeRoute(
-    Description('Test girder client is generated and can request scoped endpoints')
-	.param('file_id', 'File Id to run "some_task" on', dataType='string')))
+	Description('Launch a task, making a scoped token available to the girder_client in the task.')
+	.param('file_id', 'File Id to run "some_task" on', dataType='string'))
 def some_rest_endpoint(file_id, **params):
 	# Create a token with permissions of the current user.
-    token = ModelImporter.model('token').createToken(
-        user=self.getCurrentUser())
+	token = ModelImporter.model('token').createToken(
+		user=self.getCurrentUser())
 
-    # Launch the asynchronous task
+	# Launch the asynchronous task
 	async_result = some_task.delay(file_id, girder_client_token=token)
-	
+
 	return async_result.job
 ```
 
@@ -279,7 +292,7 @@ def some_task(self, file_id):
 	# bind is set to True in the task decorator.
 	self.girder_client.downloadFile(file_id, '/tmp/file')
 	with open('/tmp/file', 'rb') as f:
-	    # Do something with contents of f
+		# Do something with contents of f
 
 ```
 
@@ -289,10 +302,10 @@ In this example the producer side REST endpoint creates a token with the scope o
 
 *Note that this is taken almost directly from [Writing your own plugin](http://girder-worker.readthedocs.io/en/latest/developer-docs.html#writing-your-own-plugin)*
 
-Adding additional tasks to the girder\_worker infrastructure is easy and takes three steps. 
+Adding additional tasks to the girder\_worker infrastructure takes three steps. 
 
-1. Creating tasks
-2. Creating a plugin class 
+1. Creating tasks in a Python package
+2. Creating a plugin class that informs Girder Worker there are tasks in the Python package
 3. Adding a girder\_worker\_plugins [entry point](http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins) to your setup.py.
 
 Creating tasks follows the [standard celery conventions](http://docs.celeryproject.org/en/latest/userguide/tasks.html#basics). The only difference is the celery application that decorates the function should be imported from girder_worker.app. E.g.:
@@ -301,19 +314,19 @@ Creating tasks follows the [standard celery conventions](http://docs.celeryproje
 from girder_worker.app import app
 
 @app.task
-def fibonacci(n):
-    if n == 1 or n == 2:
-        return 1
-    return fibonacci(n-1) + fibonacci(n-2)
-	
+def fibonacci(n, **kwargs):
+	if n == 1 or n == 2:
+		return 1
+	return fibonacci(n-1) + fibonacci(n-2)
+
 ```
 
-Each plugin must define a plugin class the inherits from ```girder_worker.GirderWorkerPluginABC```. GirderWorkerPluginABC's interface is simple. The class must define an \_\_init\_\_ function and a task\_imports function. \_\_init\_\_ takes the girder\_worker's celery application as its first argument. This allows the plugin to store a reference to the application, or change configurations of the application as necessary. The task\_imports function takes no arguments and must return a list of the package paths (e.g. importable strings) that contain the plugin’s tasks. As an example:
+As before, we'll assume that this function is defined in the ```tasks``` module of ```my_custom_package```. Each plugin must define a plugin class the inherits from ```girder_worker.GirderWorkerPluginABC```. GirderWorkerPluginABC is an abstract base class with a simple interface that must be implemented by it's subclasses. The class must define an \_\_init\_\_ function and a task\_imports function. \_\_init\_\_ takes the girder\_worker's celery application as its first argument. This allows the plugin to store a reference to the application, or change configurations of the application as necessary. The task\_imports function takes no arguments and must return a list of the package paths (e.g. importable strings) that contain the plugin’s tasks. As an example:
 
 ```python
 from girder_worker import GirderWorkerPluginABC
 
-class GWExamplePlugin(GirderWorkerPluginABC):
+class MyCustomPackagePlugin(GirderWorkerPluginABC):
     def __init__(self, app, *args, **kwargs):
         self.app = app
 
@@ -325,11 +338,11 @@ class GWExamplePlugin(GirderWorkerPluginABC):
         })
 
     def task_imports(self):
-        return ['gwexample.analyses.tasks']
+        return ['my_custom_package.tasks']
 		
 ```
 
-Finally, in order to make the plugin class discoverable, each plugin must define a custom entry point in its setup.py. For our example, this entry point looks like this:
+Setuptool's entry points are a way for python packages to advertise classes and objects to other installed packages. In order to make the plugin class discoverable by Girder Worker, each plugin must define a custom entry point in its setup.py. For our example, this entry point looks like this:
 
 ```python
 from setuptools import setup
@@ -338,14 +351,14 @@ setup(name='gwexample',
       # ....
       entry_points={
           'girder_worker_plugins': [
-              'gwexample = gwexample:GWExamplePlugin',
+              'my_custom_package = my_custom_package:MyCustomPackagePlugin',
           ]
       },
       # ....
       )
 ```
 
-Python Entry Points are a way for python packages to advertise classes and objects to other installed packages. Entry points are defined in the following way:
+Entry points are defined in the following way:
 
 ```python
 entry_points={
@@ -355,7 +368,9 @@ entry_points={
 }
 ```
 
-The girder\_worker package introduces a new entry point group girder\_worker\_plugins. This is followed by a list of strings which are parsed by setuptools. The strings must be in the form name = module:plugin\_class Where name is an arbitrary string (by convention the name of the plugin), module is the importable path to the module containing the plugin class, and plugin_class is a class that inherits from GirderWorkerPluginABC.
+For more on entry points,  see the [setuptool's documentation](http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins).
+
+The girder\_worker package introduces a new entry point girder\_worker\_plugins. This is followed by a list of strings which are parsed by setuptools at install time. The strings must be in the form name = module:plugin\_class Where name is an arbitrary string (by convention the name of the plugin), module is the importable path to the module containing the plugin class, and plugin_class is a class that inherits from GirderWorkerPluginABC.
 
 Once you have defined your tasks, created a plugin class, setup your entrypoint, and installed your package, you can verify that your task is being properly discovered by running
 
@@ -421,15 +436,15 @@ You may additionally wish to configure setuptools using [extras_require](http://
 
 ```python
 setup(
-    name="my_custom_package",
-    ...
+	name="my_custom_package",
+
 	install_requires=[
 		"girder_worker",
 		....
 	],
-    extras_require={
-        'consumer':  ["complex_dependency", ...],
-    }
+	extras_require={
+		'consumer':  ["complex_dependency", ...],
+	}
 	...
 )
 ```
@@ -438,11 +453,11 @@ This means the producer side code can be installed with pip as ```my_custom_pack
 
 ## Communicating with Girder from inside Tasks
 
-Tasks decorated with the Girder Worker application object have two main channels of interacting with the Girder instance that produced the task. 
+Tasks decorated with the Girder Worker application object have two main channels of interacting with the Girder deployment that produced the task. 
 
-The first is the ```job_manager``` which provides an API for interacting with the specific Girder job model that is reflecting the state of Celery Task. The job_manger is an instance of ```girder_worker.utils.JobManager```. The job\_manager is available on the task object,  which means you must decorate the task with bind equal to true (e.g. ```@app.task(bind=true)```). This means the first argument to the task will be ```self``` and the job\_manger will be available as ```self.job_manager```.  For the most part,  task state transition is handled seamlessly through Girder Worker's use of [Celery Signals](http://docs.celeryproject.org/en/latest/userguide/signals.html). This means basic state transition (e.g.  running, success, failure, retry, etc) will be handled without any intervention within the task.  If you wish to use custom states,  update the Job progress, or to log specific information within your task,  you can do so using the this job\_manager. The job_manager is automatically generated regardless of whether you use the Traditional method or the Celery method of producing your task. The job\_manager is scoped so that it only has push access to the specific job it is assigned. If your task needs to leverage other components of the Girder REST API, including pushing data back to Girder or modifying Girder collections via the API,  then you should use the ```girder_client```
+The first is the ```job_manager``` which provides an API for interacting with the specific Girder job model that is reflecting the state of Celery Task. The job_manger is an instance of ```girder_worker.utils.JobManager```. The job\_manager is available on the task object, which means you must decorate the task with bind equal to true in order to access the job_manager (e.g. @app.task(bind=true)). This means the first argument to the task will be ```self``` and the job\_manger will be available as ```self.job_manager```.  For the most part,  task state transition is handled seamlessly through Girder Worker's use of [Celery Signals](http://docs.celeryproject.org/en/latest/userguide/signals.html). This means basic Job state transition (e.g.  running, success, failure, retry, etc) will be handled without any intervention within the task.  If you wish to use custom Job states,  update the Job progress, or to log specific information to the Job from within your task,  you can do so using the this job\_manager. The job_manager is automatically generated regardless of whether you use the Traditional method or the Celery method of producing your task. The job\_manager is scoped so that it only has push access to the specific job it is assigned. If your task needs to leverage other components of the Girder REST API, including pushing data back to Girder or modifying Girder collections via the API,  then you should use the ```girder_client```
 
-The second channel for interacting with Girder from within a task is through the ```girder_client``` attribute.  Like the ```job_manager``` it is available on the Celery task object (so you must set bind equal to true to access it). The girder\_client is an instance of ```girder_client.GirderClient```. It provides an authenticated session for making REST requests against the Girder API. The authentication is handled through a token provided to the task through the reserved keyword ```girder_client_token```. This will allow the girder\_client within the task to act with the same permissions granted to the token. By default the girder\_client\_token is None,  meaning the girder\_client instance within the task will have the permissions of an unauthenticated user.
+The second channel for interacting with Girder from within a task is through the ```girder_client``` attribute.  Like the ```job_manager``` it is available on the Celery task object (so you must set bind equal to true to access it). The girder\_client is an instance of ```girder_client.GirderClient```. It provides an authenticated session for making REST requests against the Girder API. The authentication is handled through a token provided to the task through the reserved keyword ```girder_client_token```. This will allow the girder\_client within the task to act with the same permissions granted to the token. If you have not set the ```girder_client_token``` then by default it is None.  This means the girder\_client instance within the task will have the permissions of an unauthenticated user.
 
 
 # Integration Testing with Girder Worker
@@ -463,6 +478,9 @@ TODO
 
 
 ## Issues with the Traditional Method
-The fundamental issue with the Traditional Method is how does one synchronize Celery's configuration across producer (Girder) and consumer (Girder Worker) processes, keeping in mind that these processes may be taking place on two (or more) different physical machines. Traditionally Celery solves this problem through the Python import mechanism. The Celery application is configured as apart of the python package in which it is defined. By importing the application you get the same configuration on the producer as on the consumer. Assuming you are using the same version on both producer and consumer, then application is imported consumer-side when running ```girder-worker``` and is imported implicitly producer-side when importing a Celery Task object (e.g. ```from my_custom_package.tasks import fibonacci```).
+When decorating a function and turning it into a task object, what you've really done is given the function two purposes in life. The first purpose is to execute the body of the function. The second purpose is to act as a factory for producing messages. When you use the Traditional method, you skip the factory entirely and just put a message on the queue using ```app.send_task(...)```. This means task specific configuration that effects the message behavior between when you call a factory method .delay(...) and when you put the message on the queue is lost (for example rate limiting the message production). The fundamental issue with the Traditional method is how does one synchronize Celery's configuration across producer (Girder) and consumer (Girder Worker) processes, keeping in mind that these processes may be taking place on two (or more) different physical machines. Traditionally Celery solves this problem through the Python import mechanism. The Celery application is configured as a part of the python package in which it is defined. By importing the application you get the same configuration on the producer as on the consumer. Assuming you are using the same version on both producer and consumer, then the application is imported consumer-side when running ```girder-worker``` and is imported implicitly producer-side when importing a Celery Task object (e.g. ```from my_custom_package.tasks import fibonacci```).
 
-The traditional method does not use Celery Task objects to produce messages (e.g. with the ```.delay(...)``` or ```.apply_async(...)``` task methods). Instead it uses the ```Celery.send_task(...)``` method which is set on the Celery application object. ```.send_taks(...)``` is the lowest level API for producing messages in Celery.  Rather than using a task object which is generated from a wrapped Python function it uses the task "name" (usually the string-ified importable path to the task). The advantage here is that the task does not need to be importable on the producer-side system, it doesn't even have to be installed at all. However,  because the task object itself is not producing the message all producer-side task level configuration is lost when using ```Celery.send_task(...)```. This might not be a deal-breaker except that the application object on the Girder producer-side is a *different application object* than on the Girder Worker consumer-side. The worker plugin does not import the ```girder_worker.app``` application object, instead it fabricates a new ```Celery(...)``` object before calling ```.send_task(...)```. While on the one hand this means the girder_worker package doesn't need to be installed in the girder environment it *also* means that the Celery application object on the producer-side is a differently configured object then on the consumer-side. Maybe that isn't a problem for you and your use-case (Celery has excellent defaults), but if you need more sophisticated configurations then currently the "Celery" method for remote task execution is your only option.
+The traditional method does not use Celery Task objects to produce messages (e.g. with the ```.delay(...)``` or ```.apply_async(...)``` task methods). Instead it uses the ```Celery.send_task(...)``` method which is defined on the Celery application object. ```.send_tasks(...)``` is the lowest level API for producing messages in Celery.  Rather than using a task object which is generated from a wrapped Python function it uses the task "name" (usually the string-ified importable path to the task). The advantage here is that the task does not need to be importable on the producer-side system, it doesn't even have to be installed at all. However,  because the task object itself is not producing the message all producer-side task level configuration is lost when using ```Celery.send_task(...)```. This might not be a deal-breaker except that the application object on the Girder producer-side is a *different application object* than on the Girder Worker consumer-side. The worker plugin does not import the ```girder_worker.app``` application object, instead it fabricates a new ```Celery(...)``` object before calling ```.send_task(...)```. While on the one hand this means the girder_worker package doesn't need to be installed in the girder environment it *also* means that the Celery application object on the producer-side is a differently configured object then on the consumer-side. Celery has excellent defaults, ans so maybe that isn't a problem for you and your use-case. If however, you need more sophisticated configurations than the defaults then currently the "Celery" method for remote task execution is your only option.
+
+### Note on using python packages as synchronizing mechanism in Celery
+Importable packages tightly bind code and configuration, which at first glance may seem bad. In fact this is critical because the configuration is fundamentally about how your code will be executed. Maintaining those in the same place reduces complexity and makes synchronization errors less likely. An importable package is also a pre-requisite for at least the consumer side of the equation (so the task can actually execute its function body). Importable packages prevent having to run a specific service to manage configuration, or sync configuration files across systems, they provide a versioned environment that ensures consistent interpretations of configuration values. Importable packages have strong tooling around their installation and deployment (pip) and once they are installed they have 100% up time.

--- a/tests/integration/HACKING.md
+++ b/tests/integration/HACKING.md
@@ -1,0 +1,464 @@
+# What is this all about?
+In this documentation we will descend through increasingly detailed descriptions of Girder Worker and it's relationship to [Celery](http://www.celeryproject.org/), ending up with descriptions of how you can use Girder Worker to run remote, asynchronous, tasks in your own extensions to Girder.
+
+## 10,000 foot view
+Girder Worker is an application that wraps Celery; it relies on Celery's distributed task execution mechanisms to do work, while reflecting task state and logging information back into [Girder](https://girder.readthedocs.io/) for visualization, debugging and management. Girder Worker is designed to receive and execute tasks that have been produced by Girder. Messages that encode what tasks and task arguments are passed from Girder to Girder Worker via a separate service called a [broker](http://docs.celeryproject.org/en/latest/getting-started/brokers/). In many common setups this broker is [RabbitMQ](https://www.rabbitmq.com/). 
+
+Girder Worker runs in a separate process from Girder. It may run on the same physical machine as Girder,  or may be run on one or more separate machines. At a low level, RabbitMQ brokers the communication between Girder and Girder Worker.  If Girder and Girder Worker are running on separate machines, both machines must be able to connect to the server running RabbitMQ.
+
+Assuming you have configured girder-worker to connect to the RabbitMQ service, running Girder Worker is easy. From a command line simply run:
+
+```python
+$> girder-worker
+```
+
+Or if you are using [systemd](https://www.freedesktop.org/wiki/Software/systemd/) you may create a simple service file:
+
+```sh
+[Unit]
+Description=Girder Worker Service
+After=network.target
+
+[Service]
+Type=simple
+User=GIRDER_USER
+Group=GIRDER_GROUP
+
+ExecStart=/path/to/girder-worker
+ExecStop=/path/to/bin/celery multi stopwait worker
+
+[Install]
+WantedBy=multi-user.target
+```
+Replace ```GIRDER_USER``` and ```GIRDER_GROUP``` with the user and group you want the service to run as. Save the file as ```/etc/systemd/system/girder_worker.service``` and run ```sudo systemctl daemon-reload```. Finally execute ```systemctl start girder_worker``` to run the girder_worker service.
+
+### Vocabulary
+
+Vocabulary can be an area of confusion when dealing with these systems. In an attempt to be clear we will draw a strong, jargon-like, distinction between the terms *Job* and *Task*.
+
+The term **Job** will always refer to the concept of a Girder [Job](http://girder.readthedocs.io/en/latest/plugins.html#jobs). Jobs are displayed on the Job's panel in Girder. They are represented in the database as [Job Models](https://github.com/girder/girder/blob/master/plugins/jobs/server/models/job.py). Girder Job's have various states and notification streams, and can be scheduled to execute on Girder Worker. 
+
+The term **Task** on the other hand will always refer to the Celery concept of a [Task](http://docs.celeryproject.org/en/latest/userguide/tasks.html). Tasks are typified by decorated python functions that can be scheduled to run on Girder Worker via the Celery [task calling api](http://docs.celeryproject.org/en/latest/userguide/calling.html). They are not persisted in any database but exist as python objects which are imported from a package. 
+
+Related to tasks are [messages](http://docs.celeryproject.org/en/latest/internals/protocol.html). A **Message** is the serialized task object that is placed on a broker's queue. By default, serialization is achieved by creating a dictionary of the function name, the arguments, keyword arguments and message metadata and then serializing this dictionary as a JSON string. Usually message serialization and queuing happens on the Girder side,  this is called *producing* a message, and in this case you might describe Girder as a **Producer** (Note that it is possible for other things to produce messages including Girder Worker. This usually takes place when functions are chained together using celery's [canvas](https://github.com/OpenGeoscience/ktile/pull/21#issuecomment-313379362) features). In our case, Girder Worker usually pulls messages off of the queue, deserializes them back into Celery Task objects and then applies those task objects to the arguments and keyword arguments encoded in the message.  This is usually referred to as *consuming* a message and makes Girder Worker a **Consumer**.
+
+To Recap:
+
++ **Job** - The Girder model that provides UI for the Celery Task
++ **Task** - The Celery object that wraps a developer defined function
++ **Message** - A serialized Task object and its arguments
++ **Producer** - Anything that generates a message with its arguments and places it on the queue.
++ **Consumer** - Anything that dequeues a message, deserializes it into a Task object and applies that object to the message arguments.
+
+## 1,000 foot view
+
+There are currently two ways of using Girder to produce messages for consumption by Girder Worker. The first, called the "Traditional" method is to use the [Worker](http://girder.readthedocs.io/en/latest/plugins.html#remote-worker) plugin to create and schedule a Girder job. The worker job handler then produces a celery message and places it on the queue for consumption by Girder Worker. This is the *Job creates Task* approach. The second (and preferred) approach is the "Celery" way. In this approach a celery task object is imported from a package and called using the standard celery API (e.g. with the ```.delay(...)``` or the ```.apply_async(...)``` methods). As long as the task object inherits from custom task class ```girder_worker.app.Task``` then this approach will create a Girder Job automatically. This is the *Task creates Job* approach. 
+
+### An Example Task
+To illustrate the differences between the traditional and celery methods of executing remote tasks we'll use a dummy task ```fibonacci``` that inefficiently calculates the [Fibonacci](https://en.wikipedia.org/wiki/Fibonacci_number) number of an input parameter ```n```:
+
+```python
+from girder_worker.app import app
+
+@app.task
+def fibonacci(n, **kwargs):
+    if n == 1 or n == 2:
+        return 1
+    return fibonacci(n-1) + fibonacci(n-2)
+```
+
+Tasks such as this must be placed be available in a package installed in the Girder Worker environment. For our purposes we will assume this task can be imported from ```my_custom_package.tasks```
+
+For Example:
+```python
+from my_custom_package.tasks import fibonacci
+``` 
+
+*Note that in various girder_worker tests we use an inefficient implementation of fibonacci because it nicely simulates a long running, computationally intensive, function*
+
+## The Traditional Method
+
+To run the fibonacci task remotely through Girder Worker using the traditional method,  we must create a Girder job, save that job, and schedule it using the Worker plugin. To produce a Celery message using the traditional method two conditions must be met. (1) the Worker plugin must be enabled from the admin plugins panel and (2) the ```handler``` key word argument must be set to the string ```worker_handler```. 
+
+The following code illustrates how to create, save, and schedule the fibonacci job:
+
+```python
+from girder.utility.model_importer import ModelImporter
+
+...
+
+# get the job model singleton which uses the factory method createJob
+jobModel = ModelImporter.model('job', 'jobs')
+
+# Create the job
+job = jobModel.createJob(
+    title='<NAME OF THE JOB>',
+    type='<JOB TYPE>', handler='worker_handler',
+    user=getCurrentUser(), public=False, args=(20,), kwargs={},
+    otherFields={
+        'celeryTaskName': 'my_custom_package.tasks.fibonacci'
+    })
+
+# Save the job
+jobModel.save(job)
+
+# Schedule the job
+jobModel.scheduleJob(job)
+
+return job
+```
+
+*This is code you might see in a REST request handler that is dedicated to launching fibonacci jobs. See the [Jobs](http://girder.readthedocs.io/en/latest/plugins.html?highlight=schedule#jobs) documentation for more information about creating, saving and scheduling jobs.*
+
+In the above code we get the job model singleton which uses a [factory](https://en.wikipedia.org/wiki/Factory_method_pattern) method ```createJob(...)``` to create the job. In our example you should replace the ```title``` and ```type``` keyword arguments with values that make sense for your purposes. Note that ```type``` is a arbitrary string used to categorize jobs, it has no inherent semantic value. ```user``` should be an instance of a user model,  the job will 'belong' to this user. ```public``` effects whether or not only the ```user``` can see the job or not. ```args``` Is a list of arguments to apply the consumer-side task object too (In our example ```n``` in ```my_custom_package.tasks.fibonacci``` will be 20). ```kwargs``` is a list of keyword arguments to apply the consumer-side task object too (In our example none). ```handler``` in our case *must be* ```"worker_handler"``` or the Worker plugin handler will not execute and the Celery message will not be produced. Finally ```otherFields``` is a dictionary of fields that are specific to Worker plugin job models. 
+
+Currently the Worker plugin supports two ```otherFields```:
+
++ **celeryTaskName** should be the name of the task object. This is almost always the python importable path to the task as a string (unless you have specifically set the [name](http://docs.celeryproject.org/en/latest/userguide/tasks.html#names) when decorating the function). In our example this is the string "my_custom_package.tasks.fibonacci". If you do not specify a ```celeryTaskName``` in ```otherFields``` it will use "girder_worker.run" by default.
++ **celeryQueue** allows you to place the produces message on a different RabbitMQ queue than the default ```celery``` queue.
+
+For the final part of our example we use the jobModel singleton to save the job to the database and then schedule the job to execute. 
+
+### Notes about the Traditional method
+
+In general the traditional method is not the preferred method for producing tasks from Girder. As we will see, it takes several additional steps compared to the "Celery" method. More importantly, the traditional method can ***only*** use the default Celery [configurations](http://docs.celeryproject.org/en/latest/userguide/configuration.html) with the exception of the backend, and broker settings (for why, see "Issues with the Traditional Method" under the architectural notes section). 
+
+The one advantage of the traditional approach is that it does not require the package that defines your task objects to be installed in the Producer's environment (e.g. ```my_custom_package``` in our example does not have to be installed on the same server as Girder). This can be helpful if for some reason you do not have deploy time control over the Girder environment,  or if you have a particularly difficult set of dependencies that would need to be installed in both the Girder and Girder Worker Python environments (though,  See: "What if my task has complex install dependencies?" for suggestions on how to mitigate this issue with the Celery method). 
+
+
+## The Celery Method
+
+The Celery method for producing messages from Girder to be consumed by Girder Worker is the preferred method. This requires installing the package that contains the task (e.g. ```my_custom_package```) in the girder environment. Once this is complete the following code will produce (generated and enqueue) a message and, as a side-effect, it will create a Girder Job. 
+
+```python
+# Import the Celery Task object
+from my_custom_package.tasks import fibonacci
+...
+
+# Generate a message and place it on the queue
+async_result = fibonacci.delay(20)
+
+# Return the Girder Job
+return async_result.job
+```
+
+*Note that,  like the code for the Traditional method, this is code you might see in a REST request handler that is dedicated to launching fibonacci jobs. See the [Celery Task API]( documentation for more information about creating, saving and scheduling jobs.) for more information about how to call and configure celery tasks.*
+
+The previous code should look familiar to anyone who has used a Celery task before. The only surprising part should be referencing ```async_result.job```. Girder Worker tasks inherit from a custom base task. This base task returns a subclassed version of ```celery.result.AsyncResult``` that includes a ```job``` property.  This ```job``` attribute will return the Girder Job model that was created as a side effect of generating and en-queuing the message.  
+
+
+### Notes about the Celery Method
+
+While the Celery method is much more terse than the Traditional method,  the astute reader will recognize that it does not (as illustrated) provide the ability to modify the properties of the Girder job that is generated. In fact, using the fibonacci task introduced previously,  with the Celery method will produce a job in the Girder Job panel with the title "\<unnammed job\>". To remedy this situation a series of "special" or "reserved" Girder Worker specific keywords may be passed to any of the Celery Task API methods.  These keywords allow per-task invocation modification of the generated girder Job. They are:
+
++ **girder_job_title** This changes the job title, by default (e.g if girder\_job\_title is omitted) it is "\<unnamed job\>".
++ **girder_job_type** This changes the job type, by default it is "celery"
++ **girder_job_public** This changes the public status of the job, by default it is False
++ **girder_job_handler** This changes the job handler,  by default it is "celery_handler" (Note: do not change this unless you are sure you know what you are doing).
++ **girder_job_other_fields** This field allows you to set additional handler specific fields on the Job.  Currently the "celery_handler" has no additional standard fields. This could however be used to extend the job model data to suit application specific needs.
++ **girder_user** This field sets the girder user which belongs to the job.  It should be a full user model. By default it is the return value of ```girder.api.rest.getCurrentUser()```
+
+Here is an example of using these fields:
+
+```python
+# Import the Celery Task object
+from my_custom_package.tasks import fibonacci
+
+...
+
+# Generate a message and place it on the queue
+async_result = fibonacci.delay(20, 
+    girder_job_title='Fibonacci Job',
+	girder_job_type='my_custom_type',
+	girder_job_public=True,
+	girder_job_other_fields= {
+	    'some_custom_field': 'some_custom_value'
+	})
+
+# Return the Girder Job
+return async_result.job
+```
+
+These keyword arguments may also be passed as keyword arguments (or 'options') to the ```.apply_async(...)```, ```.s(...)``` and ```.signature(...)``` methods:
+
+```python
+async_result = fibonacci.apply_async(
+	args=(20,), 
+	kwargs={}, 
+    girder_job_title='Fibonacci Job',
+	girder_job_type='my_custom_type',
+	girder_job_public=True,
+	girder_job_other_fields= {
+	    'some_custom_field': 'some_custom_value'
+	})
+
+```
+
+Or equally:
+
+```python
+sig = fibonacci.s(20, 
+    girder_job_title='Fibonacci Job',
+	girder_job_type='my_custom_type',
+	girder_job_public=True,
+	girder_job_other_fields= {
+	    'some_custom_field': 'some_custom_value'
+	})
+	
+async_result = sig.delay()
+
+return async_result.job
+```
+
+
+#### Job Defaults
+
+The above keyword arguments can be used to set per-invocation values for the generated job model. While this is useful for specific invocations, generally Girder Job metadata will be similar across task invocations.  Default values for this metadata may be set by decorating the task definition with the ```girder_job``` decorator:
+
+```python
+from girder_worker.utils import girder_job
+from girder_worker.app import app
+
+
+@girder_job(title='Fibonacci Job',
+            type='my_custom_type',
+			public=True, otherFields={
+			    'some_custom_field': 'some_custom_value'
+			})
+@app.task
+def fibonacci(n, **kwargs):
+    if n == 1 or n == 2:
+        return 1
+    return fibonacci(n-1) + fibonacci(n-2)
+
+```
+
+Decorated like so, the ```fibonacci.delay(...)``` function will act as though the corresponding keyword arguments were passed into the function. Defaults defined with ```@girder_job``` will be over-ridden by invocation specific keyword arguments.
+
+#### Girder Client
+Two other options are also available as reserved keyword arguments. These provide the information necessary for tasks being executed on a Consumer to talk back to girder:
+
++ **girder_client_token**
++ **girder_api_url**
+
+These are **not** used in Girder job creation,  but instead provide each executing, consumer side, task with access to an instantiated [GirderClient](http://girder.readthedocs.io/en/latest/python-client.html#the-python-client-library). This client can be used to perform arbitrary RESTful calls against the girder instance. The URL location of the girder API is specified with ```girder_api_url``` keyword argument. The default ```girder_api_url``` will be the return value of ```girder.plugins.worker.utils.getWorkerApiUrl()```. The client will be instantiated with the ```girder_client_token``` as its authentication mechanism. This means the consumer-side client will have permissions that are consistent with the scopes applied to the token. The default ```girder_client_token``` is ```None```.
+
+An example:
+
+Producer side REST endpoint:
+```python
+from my_custom_module.tasks import some_task
+from girder.utility.model_importer import ModelImporter
+
+...
+
+@access.token
+@filtermodel(model='job', plugin='jobs')
+@describeRoute(
+    Description('Test girder client is generated and can request scoped endpoints')
+	.param('file_id', 'File Id to run "some_task" on', dataType='string')))
+def some_rest_endpoint(file_id, **params):
+	# Create a token with permissions of the current user.
+    token = ModelImporter.model('token').createToken(
+        user=self.getCurrentUser())
+
+    # Launch the asynchronous task
+	async_result = some_task.delay(file_id, girder_client_token=token)
+	
+	return async_result.job
+```
+
+Consumer side task:
+```python
+from girder_worker.app import app
+
+@app.task(bind=True)
+def some_task(self, file_id):
+	# Note: girder_client is available as an attribute of 'self'
+	# self (the task object) will be passed to the function if
+	# bind is set to True in the task decorator.
+	self.girder_client.downloadFile(file_id, '/tmp/file')
+	with open('/tmp/file', 'rb') as f:
+	    # Do something with contents of f
+
+```
+
+In this example the producer side REST endpoint creates a token with the scope of the current user, then passes the REST argument ```file_id``` and the token to the task object's ```.delay(...)``` function.  On the consumer side,  the task has access to the GirderClient instance through ```self.girder_client```. To get access to ```self``` the task must be decorated with ```@app.task(bind=True)``` (See [bound tasks](http://docs.celeryproject.org/en/latest/userguide/tasks.html#bound-tasks) for more information). 
+
+# How do I write a custom Celery task for Girder Worker?
+
+*Note that this is taken almost directly from [Writing your own plugin](http://girder-worker.readthedocs.io/en/latest/developer-docs.html#writing-your-own-plugin)*
+
+Adding additional tasks to the girder\_worker infrastructure is easy and takes three steps. 
+
+1. Creating tasks
+2. Creating a plugin class 
+3. Adding a girder\_worker\_plugins [entry point](http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins) to your setup.py.
+
+Creating tasks follows the [standard celery conventions](http://docs.celeryproject.org/en/latest/userguide/tasks.html#basics). The only difference is the celery application that decorates the function should be imported from girder_worker.app. E.g.:
+
+```python
+from girder_worker.app import app
+
+@app.task
+def fibonacci(n):
+    if n == 1 or n == 2:
+        return 1
+    return fibonacci(n-1) + fibonacci(n-2)
+	
+```
+
+Each plugin must define a plugin class the inherits from ```girder_worker.GirderWorkerPluginABC```. GirderWorkerPluginABC's interface is simple. The class must define an \_\_init\_\_ function and a task\_imports function. \_\_init\_\_ takes the girder\_worker's celery application as its first argument. This allows the plugin to store a reference to the application, or change configurations of the application as necessary. The task\_imports function takes no arguments and must return a list of the package paths (e.g. importable strings) that contain the plugin’s tasks. As an example:
+
+```python
+from girder_worker import GirderWorkerPluginABC
+
+class GWExamplePlugin(GirderWorkerPluginABC):
+    def __init__(self, app, *args, **kwargs):
+        self.app = app
+
+        # Update the celery application's configuration
+        # it is not necessary to change the application configuration
+        # this is simply included to illustrate that it is possible.
+        self.app.config.update({
+            'TASK_TIME_LIMIT': 300
+        })
+
+    def task_imports(self):
+        return ['gwexample.analyses.tasks']
+		
+```
+
+Finally, in order to make the plugin class discoverable, each plugin must define a custom entry point in its setup.py. For our example, this entry point looks like this:
+
+```python
+from setuptools import setup
+
+setup(name='gwexample',
+      # ....
+      entry_points={
+          'girder_worker_plugins': [
+              'gwexample = gwexample:GWExamplePlugin',
+          ]
+      },
+      # ....
+      )
+```
+
+Python Entry Points are a way for python packages to advertise classes and objects to other installed packages. Entry points are defined in the following way:
+
+```python
+entry_points={
+    'entry_point_group_id': [
+        'entry_point_name = importable.package.name:class_or_object',
+    ]
+}
+```
+
+The girder\_worker package introduces a new entry point group girder\_worker\_plugins. This is followed by a list of strings which are parsed by setuptools. The strings must be in the form name = module:plugin\_class Where name is an arbitrary string (by convention the name of the plugin), module is the importable path to the module containing the plugin class, and plugin_class is a class that inherits from GirderWorkerPluginABC.
+
+Once you have defined your tasks, created a plugin class, setup your entrypoint, and installed your package, you can verify that your task is being properly discovered by running
+
+```sh
+girder-worker -l info
+```
+
+This should provide a list of discovered tasks under ```[tasks]```:
+
+```sh
+(girder)$ girder-worker -l info
+
+ -------------- celery@host v4.0.2
+---- **** -----
+--- * ***  * -- Linux-4.8.6-1-ARCH-x86_64-with-glibc2.2.5
+-- * - **** ---
+- ** ---------- [config]
+- ** ---------- .> app:         girder_worker:0x7f69bfff1050
+- ** ---------- .> transport:   amqp://guest:**@localhost:5672//
+- ** ---------- .> results:     amqp://
+- *** --- * --- .> concurrency: 32 (prefork)
+-- ******* ----
+--- ***** ----- [queues]
+ -------------- .> celery           exchange=celery(direct) key=celery
+
+
+[tasks]
+  . girder_worker.convert
+  . girder_worker.run
+  . girder_worker.validators
+  . gwexample.analyses.tasks.fibonacci
+
+[2016-11-08 12:22:56,163: INFO/MainProcess] Connected to amqp://guest:**@127.0.0.1:5672//
+[2016-11-08 12:22:56,184: INFO/MainProcess] mingle: searching for neighbors
+[2016-11-08 12:22:57,198: INFO/MainProcess] mingle: all alone
+[2016-11-08 12:22:57,218: WARNING/MainProcess] celery@host ready.
+```
+
+
+## What if my task has complex install dependencies? 
+
+One of the few disadvantages of the Celery method is requiring that the package that contains your task be installed on both the consumer (where the task is run) and the producer (where the task is enqueued). Normally this isn't a big problem, especially if your tasks are only using functions from Python's standard library. 
+
+In some cases however, tasks have complex dependencies that are difficult to install and it may be burdensome to install them in the producer (Girder) environment. Luckily this issue can be easily ameliorated by guarding imports in your task packages:
+
+```python
+from girder_worker.app import app
+
+try:
+	from complex_dependency import complex_function
+except ImportError:
+	pass
+
+@app.task
+def some_task(*args, **kwargs):
+	return complex_function(*args, **kwargs
+
+```
+
+Producer-side code will still generate the task objects, allowing them to produce task messages,  while consumer-side code (where the complex_dependency package must be installed) will be able to execute the task body.
+
+You may additionally wish to configure setuptools using [extras_require](http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) to manage the different between producer and consumer dependencies:
+
+```python
+setup(
+    name="my_custom_package",
+    ...
+	install_requires=[
+		"girder_worker",
+		....
+	],
+    extras_require={
+        'consumer':  ["complex_dependency", ...],
+    }
+	...
+)
+```
+
+This means the producer side code can be installed with pip as ```my_custom_package``` and the consumer side code (that includes the complex dependencies) can be installed as ```my_custom_package[consumer]```
+
+## Communicating with Girder from inside Tasks
+
+Tasks decorated with the Girder Worker application object have two main channels of interacting with the Girder instance that produced the task. 
+
+The first is the ```job_manager``` which provides an API for interacting with the specific Girder job model that is reflecting the state of Celery Task. The job_manger is an instance of ```girder_worker.utils.JobManager```. The job\_manager is available on the task object,  which means you must decorate the task with bind equal to true (e.g. ```@app.task(bind=true)```). This means the first argument to the task will be ```self``` and the job\_manger will be available as ```self.job_manager```.  For the most part,  task state transition is handled seamlessly through Girder Worker's use of [Celery Signals](http://docs.celeryproject.org/en/latest/userguide/signals.html). This means basic state transition (e.g.  running, success, failure, retry, etc) will be handled without any intervention within the task.  If you wish to use custom states,  update the Job progress, or to log specific information within your task,  you can do so using the this job\_manager. The job_manager is automatically generated regardless of whether you use the Traditional method or the Celery method of producing your task. The job\_manager is scoped so that it only has push access to the specific job it is assigned. If your task needs to leverage other components of the Girder REST API, including pushing data back to Girder or modifying Girder collections via the API,  then you should use the ```girder_client```
+
+The second channel for interacting with Girder from within a task is through the ```girder_client``` attribute.  Like the ```job_manager``` it is available on the Celery task object (so you must set bind equal to true to access it). The girder\_client is an instance of ```girder_client.GirderClient```. It provides an authenticated session for making REST requests against the Girder API. The authentication is handled through a token provided to the task through the reserved keyword ```girder_client_token```. This will allow the girder\_client within the task to act with the same permissions granted to the token. By default the girder\_client\_token is None,  meaning the girder\_client instance within the task will have the permissions of an unauthenticated user.
+
+# Architectural notes for Developers (and Masochists)
+
+The following sections contain information about the implementation details of Girder Worker. They are not meant for general consumption,  but may be useful in explaining some of the design decisions that were made for developers who wish to extend or contribute to Girder Worker.
+
+## The 'core' plugin
+TODO
+
+## Celery Hooks and the reserved keywords
+TODO
+
+## The jobInfoSpec and the task job\_manager
+TODO
+
+
+## Issues with the Traditional Method
+The fundamental issue with the Traditional Method is how does one synchronize Celery's configuration across producer (Girder) and consumer (Girder Worker) processes, keeping in mind that these processes may be taking place on two (or more) different physical machines. Traditionally Celery solves this problem through the Python import mechanism. The Celery application is configured as apart of the python package in which it is defined. By importing the application you get the same configuration on the producer as on the consumer. Assuming you are using the same version on both producer and consumer, then application is imported consumer-side when running ```girder-worker``` and is imported implicitly producer-side when importing a Celery Task object (e.g. ```from my_custom_package.tasks import fibonacci```).
+
+The traditional method does not use Celery Task objects to produce messages (e.g. with the ```.delay(...)``` or ```.apply_async(...)``` task methods). Instead it uses the ```Celery.send_task(...)``` method which is set on the Celery application object. ```.send_taks(...)``` is the lowest level API for producing messages in Celery.  Rather than using a task object which is generated from a wrapped Python function it uses the task "name" (usually the string-ified importable path to the task). The advantage here is that the task does not need to be importable on the producer-side system, it doesn't even have to be installed at all. However,  because the task object itself is not producing the message all producer-side task level configuration is lost when using ```Celery.send_task(...)```. This might not be a deal-breaker except that the application object on the Girder producer-side is a *different application object* than on the Girder Worker consumer-side. The worker plugin does not import the ```girder_worker.app``` application object, instead it fabricates a new ```Celery(...)``` object before calling ```.send_task(...)```. While on the one hand this means the girder_worker package doesn't need to be installed in the girder environment it *also* means that the Celery application object on the producer-side is a differently configured object then on the consumer-side. Maybe that isn't a problem for you and your use-case (Celery has excellent defaults), but if you need more sophisticated configurations then currently the "Celery" method for remote task execution is your only option.

--- a/tests/integration/HACKING.md
+++ b/tests/integration/HACKING.md
@@ -444,6 +444,10 @@ The first is the ```job_manager``` which provides an API for interacting with th
 
 The second channel for interacting with Girder from within a task is through the ```girder_client``` attribute.  Like the ```job_manager``` it is available on the Celery task object (so you must set bind equal to true to access it). The girder\_client is an instance of ```girder_client.GirderClient```. It provides an authenticated session for making REST requests against the Girder API. The authentication is handled through a token provided to the task through the reserved keyword ```girder_client_token```. This will allow the girder\_client within the task to act with the same permissions granted to the token. By default the girder\_client\_token is None,  meaning the girder\_client instance within the task will have the permissions of an unauthenticated user.
 
+
+# Integration Testing with Girder Worker
+TODO
+
 # Architectural notes for Developers (and Masochists)
 
 The following sections contain information about the implementation details of Girder Worker. They are not meant for general consumption,  but may be useful in explaining some of the design decisions that were made for developers who wish to extend or contribute to Girder Worker.

--- a/tests/integration/common_tasks/common_tasks/__init__.py
+++ b/tests/integration/common_tasks/common_tasks/__init__.py
@@ -9,4 +9,5 @@ class CommonTasksPlugin(GirderWorkerPluginABC):
         # Return a list of python importable paths to the
         # plugin's path directory
         return ['common_tasks.test_tasks.fib',
-                'common_tasks.test_tasks.fail']
+                'common_tasks.test_tasks.fail',
+                'common_tasks.test_tasks.girder_client']

--- a/tests/integration/common_tasks/common_tasks/test_tasks/girder_client.py
+++ b/tests/integration/common_tasks/common_tasks/test_tasks/girder_client.py
@@ -1,0 +1,11 @@
+from girder_worker.utils import girder_job
+from girder_worker.app import app
+
+
+@girder_job(title='Request Private Path')
+@app.task(bind=True)
+def request_private_path(self, user='admin'):
+    assert hasattr(self, 'girder_client')
+
+    # This will either work,  or throw an HttpError Exception
+    self.girder_client.resourceLookup('/user/%s/Private' % user)

--- a/tests/integration/integration_test_endpoints/server/__init__.py
+++ b/tests/integration/integration_test_endpoints/server/__init__.py
@@ -197,7 +197,7 @@ class IntegrationTestEndpoints(Resource):
 
         job = jobModel.createJob(
             title='test_traditional_job_custom_task_name',
-            type='worker', handler='worker_handler',
+            type='traditional', handler='worker_handler',
             user=self.getCurrentUser(), public=False, args=(number,), kwargs={},
             otherFields={
                 'celeryTaskName': 'common_tasks.test_tasks.fib.fibonacci'
@@ -219,7 +219,7 @@ class IntegrationTestEndpoints(Resource):
 
         job = jobModel.createJob(
             title='test_traditional_job_custom_task_name_fails',
-            type='worker', handler='worker_handler',
+            type='traditional', handler='worker_handler',
             user=self.getCurrentUser(), public=False, args=(), kwargs={},
             otherFields={
                 'celeryTaskName': 'common_tasks.test_tasks.fail.fail_after'
@@ -241,7 +241,7 @@ class IntegrationTestEndpoints(Resource):
         jobModel = self.model('job', 'jobs')
         job = jobModel.createJob(
             title='test_traditional_job_girder_worker_run',
-            type='worker', handler='worker_handler',
+            type='traditional', handler='worker_handler',
             user=self.getCurrentUser(), public=False, args=(self.girder_worker_run_analysis,),
             kwargs={'inputs': self.girder_worker_run_inputs,
                     'outputs': self.girder_worker_run_outputs})
@@ -262,7 +262,7 @@ class IntegrationTestEndpoints(Resource):
         jobModel = self.model('job', 'jobs')
         job = jobModel.createJob(
             title='test_traditional_job_girder_worker_run_fails',
-            type='worker', handler='worker_handler',
+            type='traditional', handler='worker_handler',
             user=self.getCurrentUser(), public=False,
             args=(self.girder_worker_run_failing_analysis,),
             kwargs={'inputs': self.girder_worker_run_inputs,

--- a/tests/integration/integration_test_endpoints/server/__init__.py
+++ b/tests/integration/integration_test_endpoints/server/__init__.py
@@ -39,6 +39,11 @@ class IntegrationTestEndpoints(Resource):
         self.route('POST', ('celery', 'test_task_signature_apply_async_fails', ),
                    self.test_celery_task_signature_apply_async_fails)
 
+        self.route('POST', ('celery', 'test_task_delay_with_custom_job_options', ),
+                   self.test_celery_task_delay_with_custom_job_options)
+        self.route('POST', ('celery', 'test_task_apply_async_with_custom_job_options', ),
+                   self.test_celery_task_apply_async_with_custom_job_options)
+
         self.route('POST', ('traditional', 'test_job_girder_worker_run'),
                    self.test_traditional_job_girder_worker_run)
         self.route('POST', ('traditional', 'test_job_custom_task_name'),
@@ -91,6 +96,26 @@ class IntegrationTestEndpoints(Resource):
         except TimeoutError:
             return None
 
+    # Testing custom job option API for celery tasks
+
+    @access.token
+    @filtermodel(model='job', plugin='jobs')
+    @describeRoute(
+        Description('Test celery task delay with custom job options'))
+    def test_celery_task_delay_with_custom_job_options(self, params):
+        result = fibonacci.delay(20, girder_job_title='TEST DELAY TITLE')
+        return result.job
+
+    @access.token
+    @filtermodel(model='job', plugin='jobs')
+    @describeRoute(
+        Description('Test celery task apply_async with custom job options'))
+    def test_celery_task_apply_async_with_custom_job_options(self, params):
+        result = fibonacci.apply_async((20,), {}, girder_job_title='TEST APPLY_ASYNC TITLE')
+        return result.job
+
+    # Testing basic celery API
+
     @access.token
     @filtermodel(model='job', plugin='jobs')
     @describeRoute(
@@ -112,7 +137,7 @@ class IntegrationTestEndpoints(Resource):
     @describeRoute(
         Description('Test celery task apply_async'))
     def test_celery_task_apply_async(self, params):
-        result = fibonacci.apply_async((20,))
+        result = fibonacci.apply_async((20,), {})
         return result.job
 
     @access.token

--- a/tests/integration/integration_test_endpoints/server/__init__.py
+++ b/tests/integration/integration_test_endpoints/server/__init__.py
@@ -143,7 +143,7 @@ class IntegrationTestEndpoints(Resource):
     @describeRoute(
         Description('Test celery task apply_async'))
     def test_celery_task_apply_async(self, params):
-        result = fibonacci.apply_async((20,), {})
+        result = fibonacci.apply_async((20,))
         return result.job
 
     @access.token
@@ -195,7 +195,6 @@ class IntegrationTestEndpoints(Resource):
     @describeRoute(
         Description('Test girder client is generated and can request scoped endpoints'))
     def test_celery_girder_client_generation(self, params):
-
         token = ModelImporter.model('token').createToken(
             user=self.getCurrentUser())
 
@@ -209,7 +208,6 @@ class IntegrationTestEndpoints(Resource):
     @describeRoute(
         Description('Test girder client with no token can\'t access protected resources'))
     def test_celery_girder_client_bad_token_fails(self, params):
-
         result = request_private_path.delay('admin', girder_client_token='')
 
         return result.job

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -50,3 +50,21 @@ def test_celery_task_fails(session, endpoint):
             [JobStatus.RUNNING, JobStatus.ERROR]
 
         assert job['log'][0].startswith('Exception: Intentionally failed after 0.5 seconds')
+
+
+def test_celery_delay_custom_job_options(session):
+    r = session.post('integration_tests/celery/test_task_delay_with_custom_job_options')
+    assert r.status_code == 200
+
+    with session.wait_for_success(r.json()['_id']) as job:
+        assert job['title'] == 'TEST DELAY TITLE'
+
+
+def test_celery_apply_async_custom_job_options(session):
+    r = session.post('integration_tests/celery/test_task_apply_async_with_custom_job_options')
+    assert r.status_code == 200
+
+    with session.wait_for_success(r.json()['_id']) as job:
+        assert job['title'] == 'TEST APPLY_ASYNC TITLE'
+
+    pass

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -67,4 +67,20 @@ def test_celery_apply_async_custom_job_options(session):
     with session.wait_for_success(r.json()['_id']) as job:
         assert job['title'] == 'TEST APPLY_ASYNC TITLE'
 
-    pass
+
+def test_celery_girder_client_generation(session):
+    r = session.post('integration_tests/celery/test_girder_client_generation')
+    assert r.status_code == 200
+
+    with session.wait_for_success(r.json()['_id']) as job:
+        assert [ts['status'] for ts in job['timestamps']] == \
+            [JobStatus.RUNNING, JobStatus.SUCCESS]
+
+
+def test_celery_girder_client_bad_token_fails(session):
+    r = session.post('integration_tests/celery/test_girder_client_bad_token_fails')
+    assert r.status_code == 200
+
+    with session.wait_for_error(r.json()['_id']) as job:
+        assert [ts['status'] for ts in job['timestamps']] == \
+            [JobStatus.RUNNING, JobStatus.ERROR]

--- a/tests/task_signal_test.py
+++ b/tests/task_signal_test.py
@@ -73,7 +73,7 @@ class TestSignals(unittest.TestCase):
 
         gcu.assert_called_once()
         create_job.assert_called_once_with(
-            **{'title': None,
+            **{'title': '<unnamed job>',
                'type': None,
                'handler': 'celery_handler',
                'public': False,

--- a/tests/task_signal_test.py
+++ b/tests/task_signal_test.py
@@ -74,7 +74,7 @@ class TestSignals(unittest.TestCase):
         gcu.assert_called_once()
         create_job.assert_called_once_with(
             **{'title': '<unnamed job>',
-               'type': None,
+               'type': 'celery',
                'handler': 'celery_handler',
                'public': False,
                'user': gcu.return_value,


### PR DESCRIPTION
This provides a cleaner approach to passing custom girder job options
through the girder_worker.app.Task object's implementation of
apply_async so that before_task_publish has access to special
arguments used for job creation,  setting the girder_api_url and
girder_client_token.

This introduces two class level variables special_headers and
special_options. special_options will not be included in the headers
sent on the message, special_headers will. In both cases if these keys
appear in delay()'s kwargs, or in apply_async()'s options they will be
popped out and placed in headers so before_task_publish can use them
to generate a girder job.