### PR TITLE
Add circleci support to run the integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: python:2.7.13
+    working_directory: /root/girder_worker
+    steps:
+      - checkout
+      - run:
+          name: Install Docker client
+          command: |
+            set -x
+            VER="17.03.0-ce"
+            curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
+            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
+            mv /tmp/docker/* /usr/bin
+      - run:
+          name: Install Docker Compose
+          command: |
+            set -x
+            curl -L https://github.com/docker/compose/releases/download/1.11.2/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
+            chmod +x /usr/local/bin/docker-compose
+      - setup_remote_docker
+      - run:
+          name: Get the environment up and running with Docker Compose
+          command: |
+            cd tests/integration && docker-compose up -d
+            # Test if girder is up and running on port 8989
+            docker run --network container:gw_integration_test_girder appropriate/curl --retry 30 --retry-delay 1 --retry-connrefused http://localhost:8989
+      - run:
+          name: Run integration tests
+          command: |
+            # Create a new container with a volume attached
+            docker create -v /cfg --name configs alpine:3.4 /bin/true
+            # Copy the repository to this volume
+            docker cp /root/girder_worker configs:/cfg
+            # Run the integration tests after installing requirements
+            docker run --volumes-from configs --network container:gw_integration_test_girder python:2.7.13 /bin/bash -c "cd /cfg/girder_worker/tests/integration; pip install -r requirements.txt; pytest -v -n 4"

--- a/tests/integration/Dockerfile.girder
+++ b/tests/integration/Dockerfile.girder
@@ -1,20 +1,10 @@
 FROM girder/girder:latest
 MAINTAINER Christopher Kotfila <chris.kotfila@kitware.com>
 
-VOLUME /girder/plugins/integration_test_endpoints
-
 RUN pip install ansible girder-client
 
 COPY ./scripts /scripts
 RUN mkdir -p /scripts/roles && ansible-galaxy install --roles-path /scripts/roles girder.girder
-
-
-COPY ./integration_test_endpoints /girder/girder/plugins/
-RUN girder-install web --plugins=integration_test_endpoints
-
-# Allow mounting integration_test_endpoints from host environment
-# e.g. for developing test endpoints
-VOLUME /girder/girder/plugins/integration_test_endpoints
 
 # Allow mounting /girder_worker
 RUN mkdir /girder_worker

--- a/tests/integration/Dockerfile.girder_worker_data_volume
+++ b/tests/integration/Dockerfile.girder_worker_data_volume
@@ -1,0 +1,9 @@
+FROM alpine:3.6
+
+COPY . /girder_worker
+
+RUN sed -i  's|^broker.*=.*$|broker = amqp://guest:guest@rabbit/|' /girder_worker/girder_worker/worker.dist.cfg
+
+VOLUME /girder_worker
+
+CMD /bin/true

--- a/tests/integration/common_tasks/common_tasks/__init__.py
+++ b/tests/integration/common_tasks/common_tasks/__init__.py
@@ -5,21 +5,6 @@ class CommonTasksPlugin(GirderWorkerPluginABC):
     def __init__(self, app, *args, **kwargs):
         self.app = app
 
-        # Note: within the context of the executing docker test
-        # environment the RabbitMQ server is addressable as 'rabbit.'
-        # Usually we statically configure the broker url in
-        # worker.local.cfg or fall back to worker.dist.cfg.  In this
-        # case however we are mounting the local girder_worker
-        # checkout inside the docker containers and don't want to
-        # surprise users by programatically modifying their
-        # configuration from the docker container's entrypoint. To
-        # solve this we set the broker URL for the girder_worker app
-        # inside the girder_worker container here.
-
-        self.app.conf.update({
-            'broker_url': 'amqp://guest:guest@rabbit/'
-        })
-
     def task_imports(self):
         # Return a list of python importable paths to the
         # plugin's path directory

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,14 +1,19 @@
 version: '2'
 services:
+  girder_worker_data_volume:
+    container_name: girder_worker_data_volume
+    build:
+      context: ../../
+      dockerfile: ./tests/integration/Dockerfile.girder_worker_data_volume
+
   girder:
     build:
       context: ./
       dockerfile: Dockerfile.girder
     image: girder/girder:gw_integration_test
     container_name: gw_integration_test_girder
-    volumes:
-      - './integration_test_endpoints/:/girder/plugins/integration_test_endpoints'
-      - '../../:/girder_worker'
+    volumes_from:
+      - girder_worker_data_volume:rw
     # Note: 4444 is for debugging with rpdb
     ports:
       - 8989:8989
@@ -25,10 +30,11 @@ services:
     # Note: 4445 is for debugging with rpdb
     ports:
       - 4445:4444
-    volumes:
-      - '../../:/girder_worker'
+    volumes_from:
+      - girder_worker_data_volume:rw
     depends_on:
       - 'rabbit'
+      - 'girder_worker_data_volume'
 
   rabbit:
     image: rabbitmq:management

--- a/tests/integration/integration_test_endpoints/server/__init__.py
+++ b/tests/integration/integration_test_endpoints/server/__init__.py
@@ -332,21 +332,6 @@ class IntegrationTestEndpoints(Resource):
 
 
 def load(info):
-
-    # Note: within the context of the executing docker test
-    # environment the RabbitMQ server is addressable as 'rabbit.'
-    # Usually we statically configure the broker url in
-    # worker.local.cfg or fall back to worker.dist.cfg.  In this case
-    # however we are mounting the local girder_worker checkout inside
-    # the docker containers and don't want to surprise users by
-    # programatically modifying their configuration from the docker
-    # container's entrypoint. To solve this we set the broker URL for
-    # the girder_worker app inside the girder container here.
-
-    app.conf.update({
-        'broker_url': 'amqp://guest:guest@rabbit/'
-    })
-
     # Note: Some endpoints rely on the celery application defined in
     # the worker plugin rather than the one defined in
     # girder_worker. This means we need to make sure the

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,4 @@
 pytest==3.1.0
 pytest-xdist==1.17.1
 requests-toolbelt==0.8.0
+six==1.10.0

--- a/tests/integration/scripts/girder_entrypoint.sh
+++ b/tests/integration/scripts/girder_entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ -e /girder_worker/tests/integration/integration_test_endpoints ]; then
+    girder-install plugin -s /girder_worker/tests/integration/integration_test_endpoints/
+else
+    echo "COULD NOT INSTALL INTEGRATION_TEST_ENDPOINTS"
+fi
+
+
 # If /girder_worker/setup.py exists then we've
 # mounted girder_worker at run time,  make sure it
 # is properly installed before continuing
@@ -16,7 +23,7 @@ fi
 
 
 # Start up Girder in the background
-(python -m girder -p 8989 -d "mongodb://mongo:27017/girder" "$@" > girder_entrypoint.log 2>&1) &
+(python -m girder -p 8999 -d "mongodb://mongo:27017/girder" "$@" > girder_entrypoint.log 2>&1) &
 
 # Wait for it to be done starting
 until grep -qi 'engine bus started' girder_entrypoint.log; do sleep 1; done;

--- a/tests/integration/scripts/gw_entrypoint.sh
+++ b/tests/integration/scripts/gw_entrypoint.sh
@@ -16,4 +16,7 @@ if [ -e /girder_worker/tests/integration/common_tasks/setup.py ]; then
     pip install -e /girder_worker/tests/integration/common_tasks/
 fi
 
+mkdir tmp
+chmod 777 tmp
+
 sudo -u worker python -m girder_worker -l info

--- a/tests/integration/scripts/setup.yml
+++ b/tests/integration/scripts/setup.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: girder
   vars:
-    girder_port: 8989
+    girder_port: 8999
     girder_user: "admin"
     girder_pass: "letmein"
   tasks:
@@ -56,7 +56,7 @@
         port: "{{ girder_port }}"
         setting:
           key: "core.server_root"
-          value: "http://girder:{{ girder_port }}/"
+          value: "http://girder:8989/"
 
     - name: Restart the server
       girder:


### PR DESCRIPTION
Runs the integration tests on CircleCi. We need to rebuild girder/girder:gw_integration_test and girder/girder_worker:gw_integration_test images and push them to Docker Hub for this to work.
@kotfic PTAL