### PR TITLE
Split entrypoint logic into a new module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ before_install:
 install:
   # install Python packages for core and all plugins
   - python scripts/install_requirements.py --mode=dev --all
+  - python setup.py develop
 
 # run tests
 script:

--- a/girder_worker/__main__.py
+++ b/girder_worker/__main__.py
@@ -1,58 +1,25 @@
-import pkg_resources as pr
-from . import config
 from ConfigParser import NoSectionError, NoOptionError
+
+from . import config
 from .app import app
-
-
-def get_plugin_tasks(ep):
-    try:
-        plugin_class = ep.load()
-
-    except Exception:
-        import traceback
-        traceback.print_exc()
-        print('Could not load \'%s\', skipping.' % str(ep))
-        return []
-
-    try:
-        plugin = plugin_class(app)
-        return plugin.task_imports()
-
-    except Exception:
-        import traceback
-        traceback.print_exc()
-        print(
-            'Problem instantiating plugin %s, skipping.'
-            % plugin_class.__name__)
-        return []
+from .entrypoint import get_core_task_modules, get_plugin_task_modules
 
 
 def main():
-    includes = []
-    for ep in pr.iter_entry_points(group='girder_worker_plugins'):
-        # If this is the girder_worker EntryPoint
-        if ep.module_name == __package__:
-            # And core_tasks config is True
-            include_core_tasks = True
-            try:
-                include_core_tasks = config.getboolean(
-                    'girder_worker', 'core_tasks')
-            except (NoSectionError, NoOptionError):
-                pass
+    try:
+        include_core_tasks = config.getboolean(
+            'girder_worker', 'core_tasks')
+    except (NoSectionError, NoOptionError):
+        include_core_tasks = True
 
-            if include_core_tasks:
-                # Load core tasks in CELERY_IMPORTS
-                # Note: CELERY_IMPORTS  guarantees that core tasks
-                #       will be loaded before all plugin tasks.
-                app.conf.update({
-                    'CELERY_IMPORTS': get_plugin_tasks(ep)})
-        else:
-            includes.extend(get_plugin_tasks(ep))
+    if include_core_tasks:
+        app.conf.update({
+            'CELERY_IMPORTS': get_core_task_modules()
+        })
 
     app.conf.update({
-        'CELERY_INCLUDE': includes
+        'CELERY_INCLUDE': get_plugin_task_modules()
     })
-
     app.worker_main()
 
 

--- a/girder_worker/entrypoint.py
+++ b/girder_worker/entrypoint.py
@@ -1,0 +1,85 @@
+from importlib import import_module
+import pkg_resources as pr
+
+from .app import app
+
+
+def get_plugin_tasks(ep):
+    """Return a list of modules containing plugin tasks.
+
+    :param ep: An entrypoint object defined by a plugin
+    :returns: A list of importable modules
+    """
+    try:
+        plugin_class = ep.load()
+
+    except Exception:
+        import traceback
+        traceback.print_exc()
+        print('Could not load \'%s\', skipping.' % str(ep))
+        return []
+
+    try:
+        plugin = plugin_class(app)
+        return plugin.task_imports()
+
+    except Exception:
+        import traceback
+        traceback.print_exc()
+        print(
+            'Problem instantiating plugin %s, skipping.'
+            % plugin_class.__name__)
+        return []
+
+
+def _import_module(module):
+    """Try to import a module given as a string."""
+    try:
+        import_module(module)
+    except ImportError:
+        import traceback
+        traceback.print_exc()
+        print('Problem importing %s' % module)
+
+
+def _get_entrypoints():
+    """Get a list of entrypoints from package resources.
+
+    :returns:
+        A tuple whose first element is the core entrypoint
+        and whose second element is a list of entrypoints
+        provided by plugins.
+    """
+    entrypoints = []
+    core = None
+    for ep in pr.iter_entry_points(group='girder_worker_plugins'):
+        # If this is the girder_worker EntryPoint
+        if ep.module_name == __package__:
+            core = ep
+        else:
+            entrypoints.append(ep)
+    return core, entrypoints
+
+
+def get_core_task_modules():
+    """Return task modules defined by core."""
+    core = _get_entrypoints()[0]
+    return get_plugin_tasks(core)
+
+
+def get_plugin_task_modules():
+    """Return task modules defined by plugins."""
+    includes = []
+    for entrypoint in _get_entrypoints()[1]:
+        includes.extend(get_plugin_tasks(entrypoint))
+    return includes
+
+
+def import_all_includes(core=True):
+    """Import all task modules for their side-effects."""
+    if core:
+        for module in get_core_task_modules():
+            _import_module(module)
+
+    for module in get_plugin_task_modules():
+        _import_module(module)

--- a/girder_worker/entrypoint.py
+++ b/girder_worker/entrypoint.py
@@ -1,35 +1,11 @@
 from importlib import import_module
-import pkg_resources as pr
 
-from .app import app
+from stevedore import extension
 
+from app import app
 
-def get_plugin_tasks(ep):
-    """Return a list of modules containing plugin tasks.
-
-    :param ep: An entrypoint object defined by a plugin
-    :returns: A list of importable modules
-    """
-    try:
-        plugin_class = ep.load()
-
-    except Exception:
-        import traceback
-        traceback.print_exc()
-        print('Could not load \'%s\', skipping.' % str(ep))
-        return []
-
-    try:
-        plugin = plugin_class(app)
-        return plugin.task_imports()
-
-    except Exception:
-        import traceback
-        traceback.print_exc()
-        print(
-            'Problem instantiating plugin %s, skipping.'
-            % plugin_class.__name__)
-        return []
+#: Defines the namespace used for plugin entrypoints
+NAMESPACE = 'girder_worker_plugins'
 
 
 def _import_module(module):
@@ -42,36 +18,43 @@ def _import_module(module):
         print('Problem importing %s' % module)
 
 
-def _get_entrypoints():
-    """Get a list of entrypoints from package resources.
+def _handle_entrypoint_errors(mgr, entrypoint, exc):
+    print('Problem loading plugin %s, skipping' % entrypoint.name)
 
-    :returns:
-        A tuple whose first element is the core entrypoint
-        and whose second element is a list of entrypoints
-        provided by plugins.
-    """
-    entrypoints = []
-    core = None
-    for ep in pr.iter_entry_points(group='girder_worker_plugins'):
-        # If this is the girder_worker EntryPoint
-        if ep.module_name == __package__:
-            core = ep
-        else:
-            entrypoints.append(ep)
-    return core, entrypoints
+
+def get_extension_manager():
+    """Get an extension manager for the plugin namespace."""
+    return extension.ExtensionManager(
+        namespace=NAMESPACE,
+        invoke_on_load=True,
+        invoke_args=(app,),
+        on_load_failure_callback=_handle_entrypoint_errors
+    )
+
+
+def get_task_imports(ext):
+    """Return a list of task modules provided by an extension."""
+    try:
+        includes = ext.obj.task_imports()
+    except Exception:
+        import traceback
+        traceback.print_exc()
+        print('Problem instantiating plugin %s, skipping' % ext.name)
+        includes = []
+    return includes
 
 
 def get_core_task_modules():
     """Return task modules defined by core."""
-    core = _get_entrypoints()[0]
-    return get_plugin_tasks(core)
+    return get_task_imports(get_extension_manager()['core'])
 
 
 def get_plugin_task_modules():
     """Return task modules defined by plugins."""
     includes = []
-    for entrypoint in _get_entrypoints()[1]:
-        includes.extend(get_plugin_tasks(entrypoint))
+    for ext in get_extension_manager():
+        if ext.name != 'core':
+            includes.extend(get_task_imports(ext))
     return includes
 
 

--- a/girder_worker/tests/plugins.py
+++ b/girder_worker/tests/plugins.py
@@ -1,0 +1,38 @@
+from girder_worker import GirderWorkerPluginABC
+
+
+class BaseTestPlugin(GirderWorkerPluginABC):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def task_imports(self):
+        return []
+
+
+class TestCore(BaseTestPlugin):
+    def task_imports(self):
+        return ['os.path']
+
+
+class TestPlugin1(BaseTestPlugin):
+    pass
+
+
+class TestPlugin2(BaseTestPlugin):
+    def task_imports(self):
+        return ['sys', 'json']
+
+
+def TestPluginException1(BaseTestPlugin):
+    def __init__(self, *arg, **kwargs):
+        raise Exception('Exception in constructor')
+
+
+def TestPluginException2(BaseTestPlugin):
+    def task_imports(self):
+        raise Exception('Exception in task_imports')
+
+
+def TestPluginInvalidModule(BaseTestPlugin):
+    def task_imports(self):
+        return ['not a valid module']

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pymongo==3.2.2
 pytz==2016.4
 requests[security]==2.10.0
 six==1.10.0
+stevedore==1.24.0

--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,18 @@ setuptools.setup(
         ],
         'girder_worker_plugins': [
             'core = girder_worker:GirderWorkerPlugin'
+        ],
+        'girder_worker.test.valid_plugins': [
+            'core = girder_worker.tests.plugins:TestCore',
+            'plugin1 = girder_worker.tests.plugins:TestPlugin1',
+            'plugin2 = girder_worker.tests.plugins:TestPlugin2'
+        ],
+        'girder_worker.test.invalid_plugins': [
+            'core = girder_worker.tests.plugins:TestCore',
+            'exception1 = girder_worker.tests.plugins:TestPluginException1',
+            'exception2 = girder_worker.tests.plugins:TestPluginException2',
+            'import = girder_worker.tests.plugins:TestPluginInvalidModule',
+            'invalid = girder_worker.tests.plugins:NotAValidClass'
         ]
     }
 )

--- a/tests/task_plugin_test.py
+++ b/tests/task_plugin_test.py
@@ -1,146 +1,75 @@
-import unittest
+import functools
 import mock
-import girder_worker
+from StringIO import StringIO
+import unittest
+
 from girder_worker import entrypoint
 from girder_worker.__main__ import main
-from pkg_resources import EntryPoint
 
 
-def mock_plugin(task_list):
-    class _MockPlugin(girder_worker.GirderWorkerPluginABC):
-        def __init__(self, app, *args, **kwargs):
-            pass
+class set_namespace(object):
+    def __init__(self, namespace):
+        self.namespace = namespace
 
-        def task_imports(self):
-            return task_list
-
-    return _MockPlugin
+    def __call__(self, func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            original = entrypoint.NAMESPACE
+            entrypoint.NAMESPACE = self.namespace
+            try:
+                result = func(*args, **kwargs)
+            finally:
+                entrypoint.NAMESPACE = original
+            return result
+        return wrapped
 
 
 class TestTaskPlugin(unittest.TestCase):
-    @mock.patch('girder_worker.entrypoint.pr')
-    @mock.patch('girder_worker.__main__.app')
-    def test_core_plugin(self, app, pr):
-        ep = EntryPoint.parse('core = girder_worker:GirderWorkerPlugin')
-        ep.load = mock.Mock(return_value=girder_worker.GirderWorkerPlugin)
-        pr.iter_entry_points.return_value = [ep]
+    @set_namespace('girder_worker.test.valid_plugins')
+    def test_get_extension_manager(self):
+        mgr = entrypoint.get_extension_manager()
+        names = sorted(mgr.names())
+        self.assertEqual(names, ['core', 'plugin1', 'plugin2'])
 
-        main()
+    @set_namespace('girder_worker.test.valid_plugins')
+    def test_get_core_task_modules(self):
+        modules = entrypoint.get_core_task_modules()
+        self.assertEqual(modules, ['os.path'])
 
-        app.conf.update.assert_any_call({'CELERY_IMPORTS':
-                                         ['girder_worker.tasks']})
-        app.conf.update.assert_any_call({'CELERY_INCLUDE': []})
-
-    @mock.patch('girder_worker.entrypoint.pr')
-    @mock.patch('girder_worker.__main__.app')
-    def test_core_and_other_plugin(self, app, pr):
-
-        core = EntryPoint.parse('core = girder_worker:GirderWorkerPlugin')
-        core.load = mock.Mock(return_value=girder_worker.GirderWorkerPlugin)
-
-        plugin = EntryPoint.parse('mock = mockplugin:MockPlugin')
-        plugin.load = mock.Mock(return_value=mock_plugin(['mock.plugin.tasks']))
-
-        pr.iter_entry_points.return_value = [core, plugin]
-
-        main()
-
-        app.conf.update.assert_any_call({'CELERY_IMPORTS':
-                                         ['girder_worker.tasks']})
-        app.conf.update.assert_any_call({'CELERY_INCLUDE':
-                                         ['mock.plugin.tasks']})
-
-    @mock.patch('girder_worker.entrypoint.pr')
-    @mock.patch('girder_worker.__main__.app')
-    def test_multiple_plugins(self, app, pr):
-
-        core = EntryPoint.parse('core = girder_worker:GirderWorkerPlugin')
-        core.load = mock.Mock(return_value=girder_worker.GirderWorkerPlugin)
-
-        plugin = EntryPoint.parse('mock = mockplugin:MockPlugin')
-        plugin.load = mock.Mock(return_value=mock_plugin(['mock.plugin.tasks']))
-
-        plugin2 = EntryPoint.parse('mock = mockplugin:MockPlugin')
-        plugin2.load = mock.Mock(return_value=mock_plugin(
-            ['mock.plugin2.tasks']))
-
-        pr.iter_entry_points.return_value = [core, plugin, plugin2]
-
-        main()
-
-        app.conf.update.assert_any_call({'CELERY_IMPORTS':
-                                         ['girder_worker.tasks']})
-        app.conf.update.assert_any_call({'CELERY_INCLUDE':
-                                         ['mock.plugin.tasks',
-                                          'mock.plugin2.tasks']})
-
-    @mock.patch('girder_worker.entrypoint.pr')
-    @mock.patch('girder_worker.__main__.app')
-    @mock.patch('girder_worker.__main__.config')
-    def test_exclude_core_tasks(self, config, app, pr):
-
-        core = EntryPoint.parse('core = girder_worker:GirderWorkerPlugin')
-        core.load = mock.Mock(return_value=girder_worker.GirderWorkerPlugin)
-        pr.iter_entry_points.return_value = [core]
-        config.getboolean.return_value = False
-
-        main()
-
-        # Called once with no plugins,  ie.  core_tasks were not added
-        app.conf.update.assert_called_once_with({'CELERY_INCLUDE': []})
-
-    @mock.patch('girder_worker.entrypoint.pr')
-    @mock.patch('girder_worker.__main__.app')
-    def test_plugin_throws_import_error(self, app, pr):
-        core = EntryPoint.parse('core = girder_worker:GirderWorkerPlugin')
-        core.load = mock.Mock(side_effect=ImportError(
-            'Intentionally throw import error'))
-        pr.iter_entry_points.return_value = [core]
-
-        main()
-
-        app.conf.update.assert_any_call({'CELERY_IMPORTS': []})
-
-    @mock.patch('girder_worker.entrypoint.pr')
-    @mock.patch('girder_worker.__main__.app')
-    def test_plugin_task_imports_throws_exception(self, app, pr):
-        core = EntryPoint.parse('core = girder_worker:GirderWorkerPlugin')
-        MockPlugin = mock_plugin([])
-        MockPlugin.task_imports = mock.Mock(side_effect=Exception(
-            'Intentionally throw exception'))
-
-        core.load = mock.Mock(return_value=MockPlugin)
-        pr.iter_entry_points.return_value = [core]
-
-        main()
-
-        app.conf.update.assert_any_call({'CELERY_IMPORTS': []})
-
-    @mock.patch('girder_worker.entrypoint.pr')
+    @set_namespace('girder_worker.test.valid_plugins')
     @mock.patch('girder_worker.entrypoint.import_module')
-    def test_import_all_task_modules(self, import_module, pr):
-        core = EntryPoint.parse('core = girder_worker:GirderWorkerPlugin')
-        core.load = mock.Mock(return_value=girder_worker.GirderWorkerPlugin)
-
-        plugin = EntryPoint.parse('mock = mockplugin:MockPlugin')
-        plugin.load = mock.Mock(return_value=mock_plugin(['mock.plugin.tasks']))
-
-        pr.iter_entry_points.return_value = [core, plugin]
-
+    def test_import_all_includes(self, imp):
         entrypoint.import_all_includes()
-        import_module.assert_any_call('mock.plugin.tasks')
+        imp.assert_has_calls(
+            (mock.call('os.path'), mock.call('json'), mock.call('sys')),
+            any_order=True
+        )
 
-    @mock.patch('girder_worker.entrypoint.pr')
-    @mock.patch('girder_worker.entrypoint.import_module')
-    def test_failed_import(self, import_module, pr):
-        import_module.side_effect = ImportError('Intentionally throw import error')
-        core = EntryPoint.parse('core = girder_worker:GirderWorkerPlugin')
-        core.load = mock.Mock(return_value=girder_worker.GirderWorkerPlugin)
+    @set_namespace('girder_worker.test.invalid_plugins')
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_invalid_plugins(self, stdout, stderr):
+        entrypoint.get_plugin_task_modules()
+        lines = stdout.getvalue().splitlines()
+        self.assertEqual(len(lines), 4)
+        for line in lines:
+            self.assertRegexpMatches(
+                line, '^Problem.*(exception[12]|invalid|import), skipping$'
+            )
 
-        plugin = EntryPoint.parse('mock = mockplugin:MockPlugin')
-        plugin.load = mock.Mock(return_value=mock_plugin(['mock.plugin.tasks']))
+        self.assertEqual(entrypoint.get_core_task_modules(), ['os.path'])
 
-        pr.iter_entry_points.return_value = [core, plugin]
+    @mock.patch('girder_worker.__main__.app')
+    def test_core_plugin(self, app):
+        main()
+        app.conf.update.assert_any_call({'CELERY_IMPORTS':
+                                         ['girder_worker.tasks']})
 
-        entrypoint.import_all_includes()
-        import_module.assert_any_call('mock.plugin.tasks')
+    @set_namespace('girder_worker.test.valid_plugins')
+    @mock.patch('girder_worker.__main__.app')
+    def test_external_plugins(self, app):
+        main()
+        app.conf.update.assert_any_call({'CELERY_IMPORTS':
+                                         ['os.path']})
+        app.conf.update.assert_any_call({'CELERY_INCLUDE':
+                                         ['sys', 'json']})


### PR DESCRIPTION
This is necessary for some of the item_tasks auto-discovery logic that I'm working on in a separate branch.  In particular, it provides a new function that will import all task modules from plugins which will serve to register all decorated tasks as a side effect.