### PR TITLE
Refactor decorated task discovery

### DIFF
--- a/girder_worker/entrypoint.py
+++ b/girder_worker/entrypoint.py
@@ -1,5 +1,6 @@
 from importlib import import_module
 
+import six
 from stevedore import extension
 import celery
 
@@ -7,14 +8,16 @@ import celery
 NAMESPACE = 'girder_worker_plugins'
 
 
-def _import_module(module):
+def _import_module(module_name):
     """Try to import a module given as a string."""
+    module = None
     try:
-        import_module(module)
+        module = import_module(module_name)
     except ImportError:
         import traceback
         traceback.print_exc()
-        print('Problem importing %s' % module)
+        print('Problem importing %s' % module_name)
+    return module
 
 
 def _handle_entrypoint_errors(mgr, entrypoint, exc):
@@ -68,3 +71,55 @@ def import_all_includes(core=True):
 
     for module in get_plugin_task_modules():
         _import_module(module)
+
+
+def get_extensions(app=None):
+    """Get a list of install extensions."""
+    return [ext.name for ext in get_extension_manager(app)]
+
+
+def get_module_tasks(module_name, celery_only=False):
+    """Get all tasks defined in a python module.
+
+    :param str module_name: The importable module name
+    :param bool celery_only: If true, only return celery tasks
+    """
+    # Import inside the function scope to prevent circular dependencies.
+    from . import describe
+    from .app import app
+
+    module = _import_module(module_name)
+    tasks = {}
+    celery_tasks = app.tasks.keys()
+
+    if module is None:
+        return tasks
+
+    for name, func in six.iteritems(vars(module)):
+        full_name = '%s.%s' % (module_name, name)
+        if celery_only and full_name not in celery_tasks:
+            # filter out non-celery tasks
+            continue
+
+        if not hasattr(func, '__call__'):
+            # filter out objects that are not callable
+            continue
+
+        try:
+            describe.get_description_attribute(func)
+            tasks[full_name] = func
+        except describe.MissingDescriptionException:
+            pass
+    return tasks
+
+
+def get_extension_tasks(extension, app=None, celery_only=False):
+    """Get the tasks defined by a girder_worker extension."""
+
+    manager = get_extension_manager(app)
+    imports = get_task_imports(manager[extension])
+    tasks = {}
+    for module_name in imports:
+        tasks.update(get_module_tasks(module_name, celery_only))
+
+    return tasks

--- a/girder_worker/tests/plugins.py
+++ b/girder_worker/tests/plugins.py
@@ -20,7 +20,7 @@ class TestPlugin1(BaseTestPlugin):
 
 class TestPlugin2(BaseTestPlugin):
     def task_imports(self):
-        return ['sys', 'json']
+        return ['girder_worker.tests.tasks']
 
 
 def TestPluginException1(BaseTestPlugin):

--- a/girder_worker/tests/tasks.py
+++ b/girder_worker/tests/tasks.py
@@ -1,0 +1,17 @@
+from girder_worker.app import app
+from girder_worker.describe import argument, types
+
+
+def not_a_task():
+    pass
+
+
+@argument('n', types.Integer)
+def function_task(n):
+    return n
+
+
+@app.task
+@argument('n', types.Integer)
+def celery_task(n):
+    return n

--- a/tests/girder_worker.coveragerc.in
+++ b/tests/girder_worker.coveragerc.in
@@ -1,3 +1,4 @@
 # Configuration for Python coverage
 [run]
 branch = @_py_branch_cov@
+omit = */tests/*


### PR DESCRIPTION
The old method of task discovery relied on an internal registry which only stored reference to bare functions.  It did not allow one to discover which functions were requested by **each** extension.  The new code searches modules on demand for valid tasks and will return celery wrapped functions where applicable.  It allows the caller to filter tasks to only those wrapped as a celery task which is important for autodiscovery in girder item_tasks plugin.