### PR TITLE
Fix a version conflict for idna when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,11 @@ except Exception:
     pass
 reqs = [unpin_version(req) for req in install_reqs]
 
+# This is a temporary measure to fix installation until a new version
+# of requests is released.  For details see:
+# https://github.com/requests/requests/issues/4222
+reqs.append('idna==2.5')
+
 # Build up extras_require for plugin requirements
 extras_require = {}
 plugins_dir = os.path.join('girder_worker', 'plugins')


### PR DESCRIPTION
Currently when installing into a new virtualenv, pip will fail with a message saying:

```
error: idna 2.6 is installed but idna<2.6,>=2.5 is required by set(['requests'])
```

This is due to requests using a `<` specifier while PyOpenSSL depends on (indirectly) `idna>=2.1`.  Because PyOpenSSL is processed first the version resolution fails for requests.  This should be fixed soon
but will continue to happen until requests stops pinning its dependencies.  See the following:

https://github.com/requests/requests/issues/4222