### PR TITLE
Add deployment step to import role into ansible-galaxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,3 +36,9 @@ jobs:
             docker cp /root/girder_worker configs:/cfg
             # Run the integration tests after installing requirements
             docker run --volumes-from configs --network container:gw_integration_test_girder python:2.7.13 /bin/bash -c "cd /cfg/girder_worker/tests/integration; pip install -r requirements.txt; pytest -v -n 4"
+
+      - deploy:
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                ./scripts/galaxy_deploy.sh
+            fi

--- a/scripts/galaxy_deploy.sh
+++ b/scripts/galaxy_deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# Ansible role repo to deploy to
+readonly ANSIBLE_ROLE_GITHUB_ORG="girder"
+readonly ANSIBLE_ROLE_GITHUB_REPO="ansible-role-girder-worker"
+
+readonly SUBTREE_PREFIX="devops/ansible/roles/girder-worker"
+readonly SUBTREE_DEST_REPO="git@github.com:$ANSIBLE_ROLE_GITHUB_ORG/$ANSIBLE_ROLE_GITHUB_REPO.git"
+readonly SUBTREE_DEST_BRANCH="master"
+
+# Make sure all git objects are accessible
+# This is useful in CI contexts where shallow clones are common
+git fetch --unshallow
+
+# Push any changes that have occurred
+git reset --hard
+git branch ansible-role-subtree
+git filter-branch --subdirectory-filter "$SUBTREE_PREFIX" ansible-role-subtree
+git push "$SUBTREE_DEST_REPO" ansible-role-subtree:"$SUBTREE_DEST_BRANCH"
+
+# Install ansible for ansible-galaxy
+pip install ansible
+
+# Import the changes into Ansible Galaxy
+ansible-galaxy login --github-token="$ANSIBLE_GALAXY_GITHUB_TOKEN"
+ansible-galaxy import "$ANSIBLE_ROLE_GITHUB_ORG" "$ANSIBLE_ROLE_GITHUB_REPO"


### PR DESCRIPTION
This commit adds a deployment step to the circle ci configuration
which will run galaxy_deploy.sh on the master branch. This means that
every time the tests pass on a commit on master (merges), a push will
occur to girder/ansible-role-girder-worker and ansible galaxy will be
told to re-import the role.

In terms of security, this requires the following:
- ANSIBLE_GALAXY_GITHUB_TOKEN be defined as an environment variable in
Circle. This is a token which allows the user:read permission.
- A read-write deploy key for ansible-role-girder-worker which allows
Circle to push to this repo (Circle has the private key).

This is the analog of https://github.com/girder/girder/pull/1966.