### PR TITLE
Check if kwargs is not None before trying to access it

### DIFF
--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -226,7 +226,7 @@ def _job_manager(request=None, headers=None, kwargs=None):
     # to girder_worker is deprecated. Newer versions of girder
     # pass this information automatically as apart of the
     # header metadata in the worker scheduler.
-    elif 'jobInfo' in kwargs:
+    elif kwargs and 'jobInfo' in kwargs:
         jobSpec = kwargs.pop('jobInfo', {})
 
     else:


### PR DESCRIPTION
While running some tasks without jobSpec I hit this:

```
[2017-08-23 20:00:27,506: ERROR/ForkPoolWorker-2] Signal handler <function gw_task_prerun at 0x7f8ccdaddb18> raised: TypeError("argument of type 'NoneType' is not iterable",)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/celery/utils/dispatch/signal.py", line 227, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/usr/local/lib/python2.7/dist-packages/girder_worker/app.py", line 257, in gw_task_prerun
    task.job_manager = _job_manager(task.request, task.request.headers)
  File "/usr/local/lib/python2.7/dist-packages/girder_worker/app.py", line 229, in _job_manager
    elif 'jobInfo' in kwargs:
TypeError: argument of type 'NoneType' is not iterable
```