### PR TITLE
Stop trying to fetch unshallow objects for galaxy deploy

### DIFF
--- a/scripts/galaxy_deploy.sh
+++ b/scripts/galaxy_deploy.sh
@@ -9,10 +9,6 @@ readonly SUBTREE_PREFIX="devops/ansible/roles/girder-worker"
 readonly SUBTREE_DEST_REPO="git@github.com:$ANSIBLE_ROLE_GITHUB_ORG/$ANSIBLE_ROLE_GITHUB_REPO.git"
 readonly SUBTREE_DEST_BRANCH="master"
 
-# Make sure all git objects are accessible
-# This is useful in CI contexts where shallow clones are common
-git fetch --unshallow
-
 # Push any changes that have occurred
 git reset --hard
 git branch ansible-role-subtree


### PR DESCRIPTION
It appears CircleCI 2 must do a complete clone instead of a shallow
one like CircleCI 1.