### PR TITLE
Wait for job to be in running state before revoking

### DIFF
--- a/tests/integration/integration_test_endpoints/server/__init__.py
+++ b/tests/integration/integration_test_endpoints/server/__init__.py
@@ -241,6 +241,8 @@ class IntegrationTestEndpoints(Resource):
         Description('Test revoking a task directly'))
     def test_celery_task_revoke(self, params):
         result = cancelable.delay()
+        # Make sure we are running before we revoke
+        assert self._wait_for_status(result.job, JobStatus.RUNNING)
         result.revoke()
 
         return result.job


### PR DESCRIPTION
Its possible for the job to be revoked before its moves into the running state depending on how quickly things are running. Add a wait for the running state to remove this timing window.