### PR TITLE
Fix pulling images with "labels" property equal to None

### DIFF
--- a/girder_worker/plugins/docker/nvidia.py
+++ b/girder_worker/plugins/docker/nvidia.py
@@ -37,8 +37,8 @@ def get_nvidia_configuration():
 
 
 def is_nvidia_image(api, image):
-    return (api.inspect_image(image).get('Config', {}).get('Labels', {}).
-            get('com.nvidia.volumes.needed') == 'nvidia_driver')
+    labels = api.inspect_image(image).get('Config', {}).get('Labels')
+    return labels and labels.get('com.nvidia.volumes.needed') == 'nvidia_driver'
 
 
 def add_nvidia_docker_to_config(container_config):


### PR DESCRIPTION
I was getting the following error because my image had `Labels` equal to `None`.  I'm not sure if this is due to an API change or not, but it seems reasonable to default to no nvidia docker support.

```python
AttributeError: 'NoneType' object has no attribute 'get'
  File "/home/jbeezley/git/girder_worker/env/lib/python2.7/site-packages/celery/app/trace.py", line 367, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/jbeezley/git/girder_worker/env/lib/python2.7/site-packages/celery/app/trace.py", line 622, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/jbeezley/git/girder_worker/girder_worker/tasks.py", line 19, in run
    return core.run(*pargs, **kwargs)
  File "/home/jbeezley/git/girder_worker/girder_worker/core/utils.py", line 123, in wrapped
    return fn(*args, **kwargs)
  File "/home/jbeezley/git/girder_worker/girder_worker/core/__init__.py", line 183, in run
    task_outputs=task_outputs, **kwargs)
  File "/home/jbeezley/git/girder_worker/girder_worker/plugins/docker/executor.py", line 302, in run
    container = _run_container(image, args, **run_kwargs)
  File "/home/jbeezley/git/girder_worker/girder_worker/plugins/docker/executor.py", line 185, in _run_container
    if nvidia.is_nvidia_image(client.api, image):
  File "/home/jbeezley/git/girder_worker/girder_worker/plugins/docker/nvidia.py", line 40, in is_nvidia_image
    return (api.inspect_image(image).get('Config', {}).get('Labels', {}).
```