### PR TITLE
Ensure _revoked_tasks always returns a list (even if empty)

### DIFF
--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -349,7 +349,12 @@ def _worker_inspector(task):
 
 # Get this list of currently revoked tasks for this worker
 def _revoked_tasks(task):
-    return _worker_inspector(task).revoked().get(task.request.hostname, [])
+    _revoked = _worker_inspector(task).revoked()
+
+    if _revoked is None:
+        return []
+
+    return _revoked.get(task.request.hostname, [])
 
 
 def is_revoked(task):


### PR DESCRIPTION
Celery's invoke.revoked(...) function may return None instead of a
list. Calling .get() on _worker_inspector may raise an AttributeError
because of this.  This ensures if None is returned _revoked_tasks
still returns an empty list.

@cjh1 PTAL
@brianhelba I believe this should resolve your issue