### PR TITLE
Update to the latest setuptools in ansible role

### DIFF
--- a/devops/ansible/roles/girder-worker/tasks/pip.yml
+++ b/devops/ansible/roles/girder-worker/tasks/pip.yml
@@ -4,6 +4,12 @@
     state: latest
     virtualenv: "{{ girder_worker_virtualenv | default(omit) }}"
 
+- name: Upgrade setuptools
+  pip:
+    name: setuptools
+    state: latest
+    virtualenv: "{{ girder_worker_virtualenv | default(omit) }}"
+
 # Install from PyPi
 - block:
     - name: Install Girder Worker


### PR DESCRIPTION
The requirements file parsing we are doing in setup.py needs a recent version setuptools.  Without this change, installing girder worker fails with:
```
Obtaining file:///home/worker/girder_worker
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/worker/girder_worker/setup.py", line 112, in <module>
        reqs = [unpin_version(req) for req in install_reqs]
      File "/home/worker/.virtualenvs/girder-worker/local/lib/python2.7/site-packages/pkg_resources.py", line 2563, in parse_requirements
        line, p, specs = scan_list(VERSION,LINE_END,line,p,(1,2),"version spec")
      File "/home/worker/.virtualenvs/girder-worker/local/lib/python2.7/site-packages/pkg_resources.py", line 2541, in scan_list
        "Expected ',' or end-of-list in",line,"at",line[p:]
    ValueError: ("Expected ',' or end-of-list in", "funcsigs==1.0.2 ; python_version < '3.3'", 'at', " ; python_version < '3.3'")

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /home/worker/girder_worker/
```