### PR TITLE
Add hostname to VM workers

### DIFF
--- a/devops/ansible/examples/girder-worker-multi-vm/Vagrantfile
+++ b/devops/ansible/examples/girder-worker-multi-vm/Vagrantfile
@@ -48,6 +48,7 @@ Vagrant.configure("2") do |config|
     config.vm.define "worker-#{i}" do |worker|
       worker.vm.box = "ubuntu/trusty64"
       worker.vm.network "private_network", ip: "192.168.33.2#{i}"
+      worker.vm.hostname = "worker-#{i}"
 
       worker.vm.provision "ansible" do |ansible|
         ansible.playbook = "playbooks/worker/site.yml"


### PR DESCRIPTION
Celery requires unique hostnames among workers (or manually passing it
with -n on the command line).