### PR TITLE
Update to the latest version of core dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ ete3==3.0.0b35
 funcsigs==1.0.2 ; python_version < '3.3'
 networkx==1.11
 Pillow==3.4.2
-pymongo==3.2.2
-pytz==2016.4
-requests[security]==2.10.0
-six==1.10.0
+pymongo==3.5.1
+pytz==2017.2
+requests[security]==2.18.4
+six==1.11.0
 stevedore==1.24.0
 girder-client==2.3.0

--- a/setup.py
+++ b/setup.py
@@ -111,11 +111,6 @@ except Exception:
     pass
 reqs = [unpin_version(req) for req in install_reqs]
 
-# This is a temporary measure to fix installation until a new version
-# of requests is released.  For details see:
-# https://github.com/requests/requests/issues/4222
-reqs.append('idna==2.5')
-
 # Build up extras_require for plugin requirements
 extras_require = {}
 plugins_dir = os.path.join('girder_worker', 'plugins')


### PR DESCRIPTION
This fixes a problem with installation via `scripts/install_requirements.py` that looks like this:
```python
Exception:
Traceback (most recent call last):
  File "/home/jbeezley/git/girder_worker/tmp/local/lib/python2.7/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/home/jbeezley/git/girder_worker/tmp/local/lib/python2.7/site-packages/pip/commands/install.py", line 335, in run
    wb.build(autobuilding=True)
  File "/home/jbeezley/git/girder_worker/tmp/local/lib/python2.7/site-packages/pip/wheel.py", line 749, in build
    self.requirement_set.prepare_files(self.finder)
  File "/home/jbeezley/git/girder_worker/tmp/local/lib/python2.7/site-packages/pip/req/req_set.py", line 380, in prepare_files
    ignore_dependencies=self.ignore_dependencies))
  File "/home/jbeezley/git/girder_worker/tmp/local/lib/python2.7/site-packages/pip/req/req_set.py", line 666, in _prepare_file
    check_dist_requires_python(dist)
  File "/home/jbeezley/git/girder_worker/tmp/local/lib/python2.7/site-packages/pip/utils/packaging.py", line 48, in check_dist_requires_python
    feed_parser.feed(metadata)
  File "/usr/lib/python2.7/email/feedparser.py", line 177, in feed
    self._input.push(data)
  File "/usr/lib/python2.7/email/feedparser.py", line 99, in push
    parts = data.splitlines(True)
AttributeError: 'NoneType' object has no attribute 'splitlines'
```
There is a bug in pip that occurs when downgrading and upgrading a package in the same process.  (I'm not certain how we just started hitting it now.)  It will crop up again when any of our pinned dependencies get updated, so this is only a short term fix.

There are a few options for a longer term fix:
1. Run `pip install` in a subprocess rather than calling `pip.main`, though there are challenges in ensuring we are running the correct `pip`.
2.  Get rid of the `-U` flag.  This won't totally solve the problem though because plugins could depend on different versions of the same package.
3.  Remove the `install_requirements.py` script and just use a single requirements file for the CI environment.