### PR TITLE
Use direct paths when possible.

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -1,7 +1,7 @@
 .. _worker-plugins:
 
 Application Plugins
-=======
+===================
 
 The Girder Worker application plugin system is used to extend the core functionality of
 Girder Worker in a number of ways. Application plugins can execute any Python code when
@@ -257,6 +257,7 @@ Girder IO
         (, "token": <girder token used for authentication>)
         (, "resource_type": <"file", "item", or "folder", default is "file">)
         (, "fetch_parent": <whether to download the whole parent resource as well, default is false>)
+        (, "direct_path": <a path on the local file system where a file resource is located>)
     }
 
 .. note :: For historical reasons, task inputs that do not specify a ``target`` field
@@ -367,6 +368,16 @@ configuration.  The following options are available:
     evicting items
   * ``diskcache_large_value_threshold`` (default=1024): cached values below this
     size are stored directly in the cache's sqlite db
+
+Direct Paths
+************
+
+If a input file resource includes a ``direct_path`` value, and that path is a locally accessible file, then Girder Worker can use the file without downloading it.  Depending on deployment, this may not be desired, as it could expose internal file system details to a task, or the path might refer to different files in the context of Girder versus Girder Worker.  To enable using direct paths, there is a configuration option:
+
+  * ``allow_direct_path`` (default=False): if True, enable using direct paths 
+    when they are specified by a input file resource.
+
+Direct paths are not used if the input file resource uses ``fetch_parent``.
 
 R
 -

--- a/girder_worker/plugins/girder_io/__init__.py
+++ b/girder_worker/plugins/girder_io/__init__.py
@@ -76,6 +76,7 @@ def fetch_handler(spec, **kwargs):
     task_input = kwargs.get('task_input', {})
     target = task_input.get('target', 'filepath')
     fetch_parent = spec.get('fetch_parent', False)
+    direct_path = spec.get('direct_path')
 
     if 'id' not in spec:
         raise Exception('Must pass a resource ID for girder inputs.')
@@ -93,6 +94,10 @@ def fetch_handler(spec, **kwargs):
     elif resource_type == 'file':
         if fetch_parent:
             dest = _fetch_parent_item(spec['id'], client, kwargs['_tempdir'])
+        elif direct_path and os.path.isfile(direct_path):
+            # If the specification includes a direct path AND it is a reachable
+            # file, use it.
+            dest = direct_path
         else:
             client.downloadFile(spec['id'], dest)
     else:

--- a/girder_worker/plugins/girder_io/__init__.py
+++ b/girder_worker/plugins/girder_io/__init__.py
@@ -93,10 +93,13 @@ def fetch_handler(spec, **kwargs):
         client.downloadItem(spec['id'], kwargs['_tempdir'], filename)
     elif resource_type == 'file':
         if fetch_parent:
+            # If we fetch the parent, we can't use direct paths as the
+            # task may needs all of the siblings next to each other
             dest = _fetch_parent_item(spec['id'], client, kwargs['_tempdir'])
-        elif direct_path and os.path.isfile(direct_path):
-            # If the specification includes a direct path AND it is a reachable
-            # file, use it.
+        elif (direct_path and config.getboolean('girder_io', 'allow_direct_path') and
+                os.path.isfile(direct_path)):
+            # If the specification includes a direct path AND it is allowed by
+            # the worker configuration AND it is a reachable file, use it.
             dest = direct_path
         else:
             client.downloadFile(spec['id'], dest)

--- a/girder_worker/plugins/girder_io/tests/girder_io_test.py
+++ b/girder_worker/plugins/girder_io/tests/girder_io_test.py
@@ -444,6 +444,48 @@ class TestGirderIo(unittest.TestCase):
             with open(file1_path, 'rb') as fd:
                 self.assertEqual(fd.read(), 'file_contents')
 
+    def test_direct_path(self):
+        task = {
+            'inputs': [{
+                'name': 'input',
+                'type': 'string',
+                'format': 'text',
+                'target': 'filepath'
+            }],
+            'outputs': [{
+                'name': 'out',
+                'type': 'string',
+                'format': 'text'
+            }],
+            'script': 'out = input',
+            'mode': 'python',
+            'cleanup': False
+        }
+
+        inputs = {
+            'input': {
+                'mode': 'girder',
+                'api_url': 'https://hello.com:1234/foo/bar/api',
+                'id': 'file1_id',
+                'name': 'text.txt',
+                'resource_type': 'file',
+                'direct_path': __file__
+            }
+        }
+
+        @httmock.all_requests
+        def girder_mock(url, request):
+            raise Exception('Unexpected %s request to %s.' % (request.method, url.path))
+
+        with httmock.HTTMock(girder_mock):
+            outputs = girder_worker.tasks.run(task, inputs=inputs,
+                                              validate=False,
+                                              auto_convert=False,
+                                              cleanup=False)
+            self.assertIn('out', outputs)
+            path = outputs['out']['data']
+            self.assertEqual(path, __file__)
+
     def test_metadata_output(self):
         task = {
             'inputs': [{'name': 'input', 'type': 'string', 'format': 'text'}],

--- a/girder_worker/worker.dist.cfg
+++ b/girder_worker/worker.dist.cfg
@@ -25,6 +25,9 @@ diskcache_size_limit=1073741824
 diskcache_cull_limit=10
 # cached values below this size are stored directly in the cache's sqlite db
 diskcache_large_value_threshold=1024
+# Set to True to allow the worker to try to use girder files directly instead
+# of only via downloading them
+allow_direct_path=False
 
 [logging]
 level=warning


### PR DESCRIPTION
If a direct_path parameter is given as part of a input specification, and that path is reachable, use it instead of downloading the file.  This only works for files where the parent is not being fetched.

This changes the girder_io plugin to use the direct path instead of download the file to the temp directory.

This changes the docker plugin to mount direct path files as their own read-only volumes.  This maintains the same level of isolation as before, except that the path name on the girder system is revealed to the worker.

See also https://github.com/girder/girder/pull/2356.