### PR TITLE
Fallback to a regular container if nvidia is unavailable.

### DIFF
--- a/girder_worker/plugins/docker/executor.py
+++ b/girder_worker/plugins/docker/executor.py
@@ -189,6 +189,14 @@ def _run_container(image, args, **kwargs):
     logger.info('Running container: image: %s args: %s kwargs: %s' % (image, args, kwargs))
     try:
         return client.containers.run(image, args, **kwargs)
+    except nvidia.NvidiaConnectionError:
+        try:
+            logger.info('Running nvidia container without nvidia support: image: %s' % image)
+            client = docker.from_env(version='auto')
+            return client.containers.run(image, args, **kwargs)
+        except DockerException as dex:
+            logger.error(dex)
+            raise
     except DockerException as dex:
         logger.error(dex)
         raise


### PR DESCRIPTION
When running an nvidia container, if we can't connect to nvidia, run as a regular container.

Ideally, it would be good if we knew if nvidia was *required* or only *preferred*.  When it is just preferred, it is better to run without nvidia support then to not run at all.