### PR TITLE
Move celery configuration into ansible

### DIFF
--- a/tests/integration/integration_test_endpoints/server/__init__.py
+++ b/tests/integration/integration_test_endpoints/server/__init__.py
@@ -41,14 +41,6 @@ class CommonTestEndpoints(Resource):
 
 
 def load(info):
-    # Note: Some endpoints rely on the celery application defined in
-    # the worker plugin rather than the one defined in
-    # girder_worker. This means we need to make sure the
-    # backend/broker are set to the rabbitmq docker container
-    settings = ModelImporter.model('setting')
-    settings.set(PluginSettings.BACKEND, 'amqp://guest:guest@rabbit/')
-    settings.set(PluginSettings.BROKER, 'amqp://guest:guest@rabbit/')
-
     info['apiRoot'].integration_tests = Prefix()
     info['apiRoot'].integration_tests.common = CommonTestEndpoints()
     info['apiRoot'].integration_tests.celery = CeleryTestEndpoints()

--- a/tests/integration/integration_test_endpoints/server/__init__.py
+++ b/tests/integration/integration_test_endpoints/server/__init__.py
@@ -1,9 +1,6 @@
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import Resource, Prefix
-from girder.utility.model_importer import ModelImporter
-
-from girder.plugins.worker.constants import PluginSettings
 
 from girder_worker.app import app
 from celery.exceptions import TimeoutError

--- a/tests/integration/scripts/setup.yml
+++ b/tests/integration/scripts/setup.yml
@@ -63,6 +63,19 @@
         delay: 5
       when: plugins.changed
 
+    - name: Configure Celery
+      girder:
+        username: "{{ girder_user }}"
+        password: "{{ girder_pass }}"
+        port: "{{ girder_port }}"
+        setting:
+          key: "{{item}}"
+          value: amqp://guest:guest@rabbit/
+        state: present
+      with_items:
+        - "worker.broker"
+        - "worker.backend"
+
     - name: Include additional setup tasks
       include: "{{ item }}"
       with_fileglob:

--- a/tests/integration/scripts/setup.yml
+++ b/tests/integration/scripts/setup.yml
@@ -39,16 +39,6 @@
         state: present
       register: plugins
 
-    - name: Enable integration test endpoints plugin
-      girder:
-        username: "{{ girder_user }}"
-        password: "{{ girder_pass }}"
-        port: "{{ girder_port }}"
-        plugins:
-          - integration_test_endpoints
-        state: present
-      register: plugins
-
     - name: Set the server root setting
       girder:
         username: "{{ girder_user }}"


### PR DESCRIPTION
This PR removes that hard coded configuration of celery and performs the configuration using ansible instead. This allows broker and backend URLs to be configured when running tests without using the docker-compose setup.