### PR TITLE
Update docker-py minimum version to 2.6.0

### DIFF
--- a/girder_worker/plugins/docker/requirements.txt
+++ b/girder_worker/plugins/docker/requirements.txt
@@ -1,1 +1,1 @@
-docker>=2.0
+docker>=2.6.0


### PR DESCRIPTION
This includes an upstreamed fix for IO truncation.

Fixes #187 