### PR TITLE
Remove the entrypoint code's dependency on celery

### DIFF
--- a/girder_worker/entrypoint.py
+++ b/girder_worker/entrypoint.py
@@ -2,7 +2,11 @@ from importlib import import_module
 
 import six
 from stevedore import extension
-import celery
+
+try:
+    from celery import current_app
+except ImportError:
+    current_app = None
 
 #: Defines the namespace used for plugin entrypoints
 NAMESPACE = 'girder_worker_plugins'
@@ -33,7 +37,7 @@ def _handle_entrypoint_errors(mgr, entrypoint, exc):
 def get_extension_manager(app=None):
     """Get an extension manager for the plugin namespace."""
     if app is None:
-        app = celery.current_app
+        app = current_app
 
     return extension.ExtensionManager(
         namespace=NAMESPACE,


### PR DESCRIPTION
This is in preparation for moving entrypoint and describe
functionality into girder/girder_worker_utils