### PR TITLE
Force reinstall of ansible-galaxy role

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -7,7 +7,7 @@ RUN_IN_CI=0
 
 initialize:
 	pip install -U -r requirements.txt
-	ansible-galaxy install --roles-path ./scripts/roles girder.girder
+	ansible-galaxy install --force --roles-path ./scripts/roles girder.girder
 
 ci:
 	$(eval RUN_IN_CI=1)
@@ -44,4 +44,4 @@ test:
 	fi
 
 
-.PHONY: initialize dev ci clean nuke test init
+.PHONY: initialize dev ci clean nuke test init run


### PR DESCRIPTION
This prevents the girder.girder role from growing out of date.

Also add run the .PHONY list which was accidentally omitted

@cjh1 PTAL