### PR TITLE
Fallback to a regular container if nvidia is unavailable.

### DIFF
--- a/girder_worker/docker/tasks/__init__.py
+++ b/girder_worker/docker/tasks/__init__.py
@@ -55,6 +55,14 @@ def _run_container(image, container_args,  **kwargs):
                 % (image, container_args, kwargs))
     try:
         return client.containers.run(image, container_args, **kwargs)
+    except nvidia.NvidiaConnectionError:
+        try:
+            logger.info('Running nvidia container without nvidia support: image: %s' % image)
+            client = docker.from_env(version='auto')
+            return client.containers.run(image, container_args, **kwargs)
+        except DockerException as dex:
+            logger.error(dex)
+            raise
     except DockerException as dex:
         logger.error(dex)
         raise

--- a/girder_worker/docker/tasks/__init__.py
+++ b/girder_worker/docker/tasks/__init__.py
@@ -39,9 +39,8 @@ def _pull_image(image):
     client = docker.from_env(version='auto')
     try:
         client.images.pull(image)
-    except DockerException as dex:
-        logger.error('Error pulling Docker image %s:' % image)
-        logger.exception(dex)
+    except DockerException:
+        logger.exception('Error pulling Docker image %s:' % image)
         raise
 
 
@@ -60,11 +59,11 @@ def _run_container(image, container_args,  **kwargs):
             logger.info('Running nvidia container without nvidia support: image: %s' % image)
             client = docker.from_env(version='auto')
             return client.containers.run(image, container_args, **kwargs)
-        except DockerException as dex:
-            logger.error(dex)
+        except DockerException:
+            logger.exception('Exception when running docker container without nvidia support.')
             raise
-    except DockerException as dex:
-        logger.error(dex)
+    except DockerException:
+        logger.exception('Exception when running docker container')
         raise
 
 


### PR DESCRIPTION
When running an nvidia container, if we can't connect to nvidia, run as a regular container.

Ideally, it would be good if we knew if nvidia was *required* or only *preferred*.  When it is just preferred, it is better to run without nvidia support then to not run at all.

Note: PR #201 undid this change which had been added in PR #206.