### PR TITLE
Improve test coverage for modern girder_worker infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__
 .vagrant
 .tox
 .cache
+htmlcov/

--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -148,6 +148,7 @@ class Task(celery.Task):
             if hasattr(grh, 'transform') and \
                six.callable(grh.transform):
                 return grh.transform(result, **kwargs)
+            return result
         except IndexError:
             return result
 
@@ -168,11 +169,11 @@ class Task(celery.Task):
             results = super(Task, self).__call__(*_t_args, **_t_kwargs)
 
             if hasattr(self.request, 'girder_result_hooks'):
-                if not isinstance(results, tuple):
-                    results = (results, )
-
-                results = tuple([self._maybe_transform_result(i, r)
-                                 for i, r in enumerate(results)])
+                if isinstance(results, tuple):
+                    results = tuple([self._maybe_transform_result(i, r)
+                                     for i, r in enumerate(results)])
+                else:
+                    results = self._maybe_transform_result(0, results)
 
             return results
         finally:

--- a/girder_worker/docker/io/__init__.py
+++ b/girder_worker/docker/io/__init__.py
@@ -365,7 +365,7 @@ class ChunkedTransferEncodingStreamWriter(StreamWriter):
             resp = self.conn.getresponse()
             sys.stderr.write(
                 'Exception while sending HTTP chunk to %s, status was %s, '
-                'message was:\n%s\n' % (self.output_spec['url'], resp.status,
+                'message was:\n%s\n' % (self._url, resp.status,
                                         resp.read()))
             self.conn.close()
             self._closed = True

--- a/girder_worker/docker/nvidia.py
+++ b/girder_worker/docker/nvidia.py
@@ -38,7 +38,7 @@ def get_nvidia_configuration():
 
 def is_nvidia_image(api, image):
     labels = api.inspect_image(image).get('Config', {}).get('Labels')
-    return labels and labels.get('com.nvidia.volumes.needed') == 'nvidia_driver'
+    return bool(labels and labels.get('com.nvidia.volumes.needed') == 'nvidia_driver')
 
 
 def add_nvidia_docker_to_config(container_config):

--- a/girder_worker/docker/transforms/girder.py
+++ b/girder_worker/docker/transforms/girder.py
@@ -28,7 +28,9 @@ class ProgressPipe(Transform):
 
         # TODO What do we do is job_manager is None? When can it me None?
         job_mgr = task.job_manager
-        return Connect(NamedOutputPipe(self.name, self._volume),
+        # For now we are using JobProgressAdapter which is part of core, we should
+        # probably add a copy to the docker package to break to reference to core.
+        return Connect(NamedOutputPipe(self.name, volume=self._volume),
                        JobProgressAdapter(job_mgr)).transform(**kwargs)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+import io
+import pytest
+import random
+
+
+@pytest.fixture
+def stream():
+    class MockFileStream(io.BytesIO):
+        def __init__(self, fd, *args, **kwargs):
+            self._fd = fd
+            super(MockFileStream, self).__init__(*args, **kwargs)
+
+        def fileno(self):
+            return self._fd
+
+        @property
+        def data(self):
+            return self.getvalue()
+
+        @data.setter
+        def data(self, data):
+            self.truncate()
+            self.write(data)
+            self.seek(0)
+    return MockFileStream(random.randrange(4, 100))
+
+
+istream = stream
+ostream = stream

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,331 @@
+import celery
+import pytest
+import mock
+
+from girder_worker.app import (
+    GirderAsyncResult,
+    Task,
+    _maybe_model_repr
+)
+
+
+RESERVED_HEADERS = [
+    ('girder_client_token', 'GIRDER_CLIENT_TOKEN'),
+    ('girder_api_url', 'GIRDER_API_URL'),
+    ('girder_result_hooks', 'GIRDER_RESULT_HOOKS')
+]
+
+RESERVED_OPTIONS = [
+    ('girder_user', 'GIRDER_USER'),
+    ('girder_job_title', 'GIRDER_JOB_TITLE'),
+    ('girder_job_type', 'GIRDER_JOB_TYPE'),
+    ('girder_job_public', 'GIRDER_JOB_PUBLIC'),
+    ('girder_job_handler', 'GIRDER_JOB_HANDLER'),
+    ('girder_job_other_fields', 'GIRDER_JOB_OTHER_FIELDS')
+]
+
+
+# This function returns a Task() object and tweaks the task's
+# request_stack to include a Context object. args and kwargs are
+# passed directly to the generated Context object. See:
+# celery.app.task.Context for more info.
+def _task_with_request(*args, **kwargs):
+    task = Task()
+    task.request_stack = celery.utils.threads.LocalStack()
+    task.push_request(*args, **kwargs)
+    return task
+
+
+class MockTrans(object):
+    def __init__(self, arg):
+        self.arg = arg
+
+    def transform(self, *args, **kwargs):
+        return self.arg
+
+
+class MockNonTrans(object):
+    pass
+
+
+MockNonTransObj = MockNonTrans()
+
+
+# Note: This test checks whether the
+# girder_worker.app.Task.reserved_headers are the same as the headers
+# defined in RESERVED_HEADERS. If it is failing it is probably because
+# you added a reserved header to girder_worker.app.Task and not to
+# RESERVED_HEADERS
+def test_TASK_reserved_headers_same_as_test_reserved_headers():
+    assert set(Task.reserved_headers) == set([h for h, _ in RESERVED_HEADERS])
+
+
+# Note: This test checks whether the
+# girder_worker.app.Task.reserved_options are the same as the options
+# defined in RESERVED_OPTIONS. If it is failing it is probably because
+# you added a reserved options to girder_worker.app.Task and not to
+# RESERVED_OPTIONS
+def test_TASK_reserved_options_same_as_test_reserved_options():
+    assert set(Task.reserved_options) == set([h for h, _ in RESERVED_OPTIONS])
+
+
+def test_GirderAsyncResult_job_property_returns_None_on_ImportError():
+    gar = GirderAsyncResult('BOGUS_TASK_ID')
+    assert gar.job is None
+
+
+def test_GirderAsyncResult_job_property_calls_findOne_on_girder_job_model():
+    gar = GirderAsyncResult('BOGUS_TASK_ID')
+    with mock.patch('girder.utility.model_importer.ModelImporter') as mi:
+        gar.job
+        mi.model.return_value.findOne.assert_called_once_with({
+            'celeryTaskId': 'BOGUS_TASK_ID'
+        })
+
+
+def test_GirderAsyncResult_job_property_returns_None_if_no_jobs_found():
+    gar = GirderAsyncResult('BOGUS_TASK_ID')
+    with mock.patch('girder.utility.model_importer.ModelImporter') as mi:
+        mi.model.return_value.findOne.side_effect = IndexError()
+        assert gar.job is None
+
+
+def test_Task_AsynResult_of_type_GirderAsyncResult():
+    assert isinstance(Task().AsyncResult('BOGUS_TASK_ID'), GirderAsyncResult)
+
+
+@pytest.mark.parametrize('header,expected', RESERVED_HEADERS)
+def test_Task_apply_async_reserved_headers_in_options(header, expected):
+    with mock.patch('girder_worker.app.celery.Task.apply_async', spec=True) as mock_apply_async:
+        Task().apply_async((), {},  **{header: expected})
+        margs, mkwargs = mock_apply_async.call_args
+        assert 'headers' in mkwargs
+        assert header in mkwargs['headers']
+        assert mkwargs['headers'][header] == expected
+
+
+@pytest.mark.parametrize('header,expected', RESERVED_HEADERS)
+def test_Task_apply_async_reserved_headers_in_kwargs(header, expected):
+    with mock.patch('girder_worker.app.celery.Task.apply_async', spec=True) as mock_apply_async:
+        Task().apply_async((), {header: expected})
+        margs, mkwargs = mock_apply_async.call_args
+        assert 'headers' in mkwargs
+        assert header in mkwargs['headers']
+        assert mkwargs['headers'][header] == expected
+
+
+@pytest.mark.parametrize('header,expected', RESERVED_HEADERS)
+def test_Task_delay_reserved_headers_in_kwargs(header, expected):
+    with mock.patch('girder_worker.app.celery.Task.apply_async', spec=True) as mock_apply_async:
+        Task().delay(**{header: expected})
+        margs, mkwargs = mock_apply_async.call_args
+        assert 'headers' in mkwargs
+        assert header in mkwargs['headers']
+        assert mkwargs['headers'][header] == expected
+
+
+@pytest.mark.parametrize('option,expected', RESERVED_OPTIONS)
+def test_Task_apply_async_reserved_options_in_options(option, expected):
+    with mock.patch('girder_worker.app.celery.Task.apply_async', spec=True) as mock_apply_async:
+        Task().apply_async((), **{option: expected})
+        margs, mkwargs = mock_apply_async.call_args
+        assert 'headers' in mkwargs
+        assert option in mkwargs['headers']
+        assert mkwargs['headers'][option] == expected
+
+
+@pytest.mark.parametrize('option,expected', RESERVED_OPTIONS)
+def test_Task_apply_async_reserved_options_in_kwargs(option, expected):
+    with mock.patch('girder_worker.app.celery.Task.apply_async', spec=True) as mock_apply_async:
+        Task().apply_async((), {option: expected})
+        margs, mkwargs = mock_apply_async.call_args
+        assert 'headers' in mkwargs
+        assert option in mkwargs['headers']
+        assert mkwargs['headers'][option] == expected
+
+
+@pytest.mark.parametrize('option,expected', RESERVED_OPTIONS)
+def test_Task_delay_reserved_options_in_kwargs(option, expected):
+    with mock.patch('girder_worker.app.celery.Task.apply_async', spec=True) as mock_apply_async:
+        Task().delay(**{option: expected})
+        margs, mkwargs = mock_apply_async.call_args
+        assert 'headers' in mkwargs
+        assert option in mkwargs['headers']
+        assert mkwargs['headers'][option] == expected
+
+
+@pytest.mark.parametrize('header,expected', RESERVED_HEADERS + RESERVED_OPTIONS)
+def test_Task_apply_async_reserved_in_options_with_existing_header_option(header, expected):
+    with mock.patch('girder_worker.app.celery.Task.apply_async', spec=True) as mock_apply_async:
+        Task().apply_async((), {}, **{header: expected, 'headers': {'some': 'header'}})
+        margs, mkwargs = mock_apply_async.call_args
+        assert 'headers' in mkwargs
+        assert header in mkwargs['headers']
+        assert mkwargs['headers'][header] == expected
+
+
+# TODO: it would be nice to check that an empty set of arguments calls
+# with an empty set of arguments, (i.e.  ```((), ())``` )
+# unfortunately this ends up throwing TypeError("'self' parameter
+# lacking default value",) which from some cursory googling looks like
+# an internal Mock thing having to do with wrapped functions.
+@pytest.mark.parametrize('arguments,transformed', [
+    ((1,),                                         (1,)                             ),  # noqa E202
+    ((1.0,),                                       (1.0,)                           ),  # noqa E202
+    (('string',),                                  ('string',)                      ),  # noqa E202
+    ((b'bytes',),                                  (b'bytes',)                      ),  # noqa E202
+    ((('tuple',),),                                (('tuple',),)                    ),  # noqa E202
+    ((['list', 'of', 'items'],),                   (['list', 'of', 'items'],)       ),  # noqa E202
+    (({'key': 'value'},),                          ({'key': 'value'},)              ),  # noqa E202
+    ((MockNonTrans, ),                             (MockNonTrans,)                  ),  # noqa E202
+    ((MockNonTransObj, ),                          (MockNonTransObj,)               ),  # noqa E202
+    (('multiple', 'arguments'),                    ('multiple', 'arguments')        ),  # noqa E202
+    ((MockTrans('TEST'),),                         ('TEST',)                        ),  # noqa E202
+    ((MockTrans('TEST1'), MockTrans('TEST2')),     ('TEST1', 'TEST2')               ),  # noqa E202
+    (('TEST1', MockTrans('TEST2')),                ('TEST1', 'TEST2')               ),  # noqa E202
+    (([MockTrans('TEST1'), MockTrans('TEST2')],),  (['TEST1', 'TEST2'],)            ),  # noqa E202
+    (((MockTrans('TEST1'), MockTrans('TEST2')),),  (('TEST1', 'TEST2'),)            ),  # noqa E202
+    (({'key': MockTrans('TEST')},),                ({'key': 'TEST'},)               ),  # noqa E202
+    (({'outer': {'inner': MockTrans('TEST')}},),   ({'outer': {'inner': 'TEST'}},)  ),  # noqa E202
+    ((MockNonTransObj,
+      {'outer': {'inner': MockTrans('TEST'),
+                 'other': MockNonTransObj}},
+      (MockTrans('TEST1'), MockNonTransObj, MockTrans('TEST2'))),
+     (MockNonTransObj,
+      {'outer': {'inner': 'TEST',
+                 'other': MockNonTransObj}},
+      ('TEST1', MockNonTransObj, 'TEST2')))
+
+], ids=[
+    'Single Int',
+    'Single Float',
+    'Single String',
+    'Single Bytes',
+    'Single Tuple',
+    'Single List',
+    'Single Dict',
+    'Single NonTrans Class',
+    'Single NonTrans Object',
+    'Multiple NonTrans Arguments',
+    'Single Trans',
+    'Multiple Trans Arguments',
+    'Mixed Trans and NonTrans Args',
+    'Single List of Trans Arguments',
+    'Single Tuple of Trans Arguments',
+    'Single Dict of Trans Arguments',
+    'Nested Dict of Trans Arguments',
+    'Complex'
+])
+def test_Task___call___transforms_or_passes_through_arguments(arguments, transformed):
+    with mock.patch('girder_worker.app.celery.Task.__call__', spec=True) as mock_call:
+        task = _task_with_request()
+        task(*arguments)
+        mock_call.assert_called_once_with(*transformed)
+
+
+# Note: We have to add 'FIXME' as an argument to task(...) and
+# mock_call to avoid the same TypeError as observed in the prevous
+# test.
+@pytest.mark.parametrize('kwargs,transformed', [
+    ({'k': 1},                                         {'k': 1}                      ), # noqa E202
+    ({'k': 1.0},                                       {'k': 1.0}                    ), # noqa E202
+    ({'k': 'string'},                                  {'k': 'string'}               ), # noqa E202
+    ({'k': b'bytes'},                                  {'k': b'bytes'}               ), # noqa E202
+    ({'k': ('some', 'tuple')},                         {'k': ('some', 'tuple')}      ), # noqa E202
+    ({'k': ['some', 'list']},                          {'k': ['some', 'list']}       ), # noqa E202
+    ({'outer': {'inner': 'value'}},                    {'outer': {'inner': 'value'}} ), # noqa E202
+    ({'k1': 'v1', 'k2': 'v2'},                         {'k1': 'v1', 'k2': 'v2'}      ), # noqa E202
+    ({'k': MockNonTransObj},                           {'k': MockNonTransObj}        ), # noqa E202
+    ({'k': MockNonTrans},                              {'k': MockNonTrans}           ), # noqa E202
+    ({'k': MockTrans('TEST')},                         {'k': 'TEST'}                 ), # noqa E202
+    ({'k': (MockTrans('TEST1'), MockTrans('TEST2'))},  {'k': ('TEST1', 'TEST2')}     ), # noqa E202
+    ({'k': [MockTrans('TEST1'), MockTrans('TEST2')]},  {'k': ['TEST1', 'TEST2']}     ), # noqa E202
+    ({'outer': {'inner': MockTrans('TEST')}},          {'outer': {'inner': 'TEST'}}  ), # noqa E202
+    ({'k': MockTrans('TEST'), 'k2': 'v2'},             {'k': 'TEST', 'k2': 'v2'}     ), # noqa E202
+    ({'k ': MockNonTransObj,
+      'k2': MockTrans('TEST'),
+      'k3': {'k ': MockTrans('TEST'),
+             'k2': MockNonTransObj},
+      'k4': (MockTrans('TEST1'), MockNonTransObj, MockTrans('TEST2'))},
+     {'k ': MockNonTransObj,
+      'k2': 'TEST',
+      'k3': {'k ': 'TEST',
+             'k2': MockNonTransObj},
+      'k4': ('TEST1', MockNonTransObj, 'TEST2')}),
+],
+ids=[
+    'Dict w/Int',
+    'Dict w/Float',
+    'Dict w/String',
+    'Dict w/Bytes',
+    'Dict w/Tuple',
+    'Dict w/List',
+    'Nestd Dict',
+    'Dict with multiple Keys',
+    'Dict w/NonTrans Obj',
+    'Dict w/NonTrans Class',
+    'Dict w/Trans Obj',
+    'Dict w/Tuple of Trans Objs',
+    'Dict w/List of Trans Objs',
+    'Nested Dict w/Trans Obj',
+    'MultiKey Dict w/Trans Obj',
+    'Complex'
+])
+def test_Task___call___transforms_or_passes_through_kwargs(kwargs, transformed):
+    with mock.patch('girder_worker.app.celery.Task.__call__', spec=True) as mock_call:
+        task = _task_with_request()
+        task('FIXME', **kwargs)
+        mock_call.assert_called_once_with('FIXME', **transformed)
+
+
+class MockResultTrans(object):
+    def __init__(self, func):
+        self.func = func
+
+    def transform(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+
+@pytest.mark.parametrize('results,hooks,transformed', [
+    (1,       (MockResultTrans(lambda x: x + 1),),       2),      # noqa E202
+    ((1, 2),  (MockResultTrans(lambda x: x + 1),
+               MockResultTrans(lambda x: x + 1)),        (2, 3)), # noqa E202
+    ((1, 2),  (MockResultTrans(lambda x: x + 1), None),  (2, 2)), # noqa E202
+    ((1, 2),  (None, MockResultTrans(lambda x: x + 1)),  (1, 3)), # noqa E202
+    ((1, 2),  (MockResultTrans(lambda x: x + 1), ),      (2, 2)), # noqa E202
+],
+ids=[
+    'Single Return Value',
+    'Tuple Return Value',
+    'Tuple, Second Trans None',
+    'Tuple, First Trans None',
+    'Tuple, Missing Tail Trans'
+])
+def test_Task___call___transforms_or_passes_through_girder_result_hooks(
+        results, hooks, transformed):
+    with mock.patch('girder_worker.app.celery.Task.__call__',
+                    return_value=results):
+        task = _task_with_request(girder_result_hooks=hooks)
+        assert task('ARG1', kwarg='KWARG1') == transformed
+
+
+class MockModelRepr(object):
+    def __init__(self, arg):
+        self.arg = arg
+
+    def _repr_model_(self):
+        return repr(self.arg)
+
+
+@pytest.mark.parametrize('obj,expected', [
+    ('string', 'string'),
+    (b'bytes', B'bytes'),
+    (1, 1),
+    (1.0, 1.0),
+    ({'key': 'value'}, {'key': 'value'}),
+    (['some', 'list'], ['some', 'list']),
+    (('tuple',), ('tuple', )),
+    (MockModelRepr('TEST'), '\'TEST\'')
+])
+def test__maybe_model_repr(obj, expected):
+    assert _maybe_model_repr(obj) == expected

--- a/tests/test_docker_io.py
+++ b/tests/test_docker_io.py
@@ -1,10 +1,8 @@
 import httplib
-import io
 import itertools
+import mock
 import os
 import pytest
-import mock
-import random
 
 from girder_worker.docker.io import (
     ChunkedTransferEncodingStreamWriter,
@@ -20,32 +18,6 @@ from girder_worker.docker.io import (
 
 from girder_worker.docker.io.girder import GirderFileStreamReader
 from girder_client import GirderClient
-
-
-@pytest.fixture
-def stream():
-    class MockFileStream(io.BytesIO):
-        def __init__(self, fd, *args, **kwargs):
-            self._fd = fd
-            super(MockFileStream, self).__init__(*args, **kwargs)
-
-        def fileno(self):
-            return self._fd
-
-        @property
-        def data(self):
-            return self.getvalue()
-
-        @data.setter
-        def data(self, data):
-            self.truncate()
-            self.write(data)
-            self.seek(0)
-    return MockFileStream(random.randrange(4, 100))
-
-
-istream = stream
-ostream = stream
 
 
 def test_FDWriteStreamConnector_fileno_same_as_output_fileno(istream, ostream):

--- a/tests/test_docker_io.py
+++ b/tests/test_docker_io.py
@@ -1,0 +1,338 @@
+import httplib
+import io
+import itertools
+import os
+import pytest
+import mock
+import random
+
+from girder_worker.docker.io import (
+    ChunkedTransferEncodingStreamWriter,
+    FDReadStreamConnector,
+    FDWriteStreamConnector,
+    FileDescriptorReader,
+    FileDescriptorWriter,
+    NamedPipe,
+    NamedPipeReader,
+    NamedPipeWriter,
+    StdStreamWriter
+)
+
+from girder_worker.docker.io.girder import GirderFileStreamReader
+from girder_client import GirderClient
+
+
+@pytest.fixture
+def stream():
+    class MockFileStream(io.BytesIO):
+        def __init__(self, fd, *args, **kwargs):
+            self._fd = fd
+            super(MockFileStream, self).__init__(*args, **kwargs)
+
+        def fileno(self):
+            return self._fd
+
+        @property
+        def data(self):
+            return self.getvalue()
+
+        @data.setter
+        def data(self, data):
+            self.truncate()
+            self.write(data)
+            self.seek(0)
+    return MockFileStream(random.randrange(4, 100))
+
+
+istream = stream
+ostream = stream
+
+
+def test_FDWriteStreamConnector_fileno_same_as_output_fileno(istream, ostream):
+    fd = FDWriteStreamConnector(istream, ostream)
+    assert fd.fileno() == ostream.fileno()
+
+
+def test_FDReadStreamConnector_fileno_same_as_input_fileno(istream, ostream):
+    fd = FDReadStreamConnector(istream, ostream)
+    assert fd.fileno() == istream.fileno()
+
+
+def test_FDWriteStreamConnector_write_istream_data_to_ostream(istream, ostream):
+    istream.data = b'Test Data'
+    FDWriteStreamConnector(istream, ostream).write()
+    assert ostream.data == b'Test Data'
+
+
+def test_FDWriteStreamConnector_open_calls_ostream_open(istream, ostream):
+    with mock.patch.object(ostream, 'open', create=True) as ostream_open:
+        FDWriteStreamConnector(istream, ostream).open()
+        ostream_open.assert_called_once()
+
+
+def test_FDWriteStreamConnector_close_on_no_istream_data(istream, ostream):
+    istream.data = b''
+    with mock.patch.object(ostream, 'close') as ostream_close:
+        with mock.patch.object(istream, 'close') as istream_close:
+            assert FDWriteStreamConnector(istream, ostream).write() == 0
+            ostream_close.assert_called_once()
+            istream_close.assert_called_once()
+
+    assert ostream.data == b''
+
+
+def test_FDReadStreamConnector_read_istream_data_to_ostream(istream, ostream):
+    istream.data = b'Test Data'
+    FDReadStreamConnector(istream, ostream).read()
+    assert ostream.data == b'Test Data'
+
+
+def test_FDReadStreamConnector_open_calls_istream_open(istream, ostream):
+    with mock.patch.object(istream, 'open', create=True) as istream_open:
+        FDReadStreamConnector(istream, ostream).open()
+        istream_open.assert_called_once()
+
+
+def test_FDReadStreamConnector_close_on_no_istream_data(istream, ostream):
+    istream.data = b''
+    with mock.patch.object(ostream, 'close') as ostream_close:
+        with mock.patch.object(istream, 'close') as istream_close:
+            assert FDReadStreamConnector(istream, ostream).read() == 0
+            ostream_close.assert_called_once()
+            istream_close.assert_called_once()
+
+    assert ostream.data == b''
+
+
+def test_FileDescriptorReader_calls_os_read():
+    with mock.patch('girder_worker.docker.io.os.read') as m:
+        fd = FileDescriptorReader(-1)
+        fd.read(65536)
+        m.assert_called_once_with(-1, 65536)
+
+
+def test_FileDescriptorReader_calls_os_close():
+    fd = FileDescriptorReader(-1)
+    with mock.patch('girder_worker.docker.io.os.close') as m:
+        fd.close()
+        m.assert_called_once_with(-1)
+
+
+def test_FileDescriptorWriter_calls_os_write():
+    with mock.patch('girder_worker.docker.io.os.write') as m:
+        fd = FileDescriptorWriter(-1)
+        fd.write(65536)
+        m.assert_called_once_with(-1, 65536)
+
+
+def test_FileDescriptorWriter_calls_os_close():
+    fd = FileDescriptorWriter(-2)
+    with mock.patch('girder_worker.docker.io.os.close') as m:
+        fd.close()
+        m.assert_called_once_with(-2)
+
+
+def test_StdStreamWriter_write_writes_to_stream(stream):
+    StdStreamWriter(stream).write(b'Test Data')
+    assert stream.data == b'Test Data'
+
+
+def test_StdStreamWriter_close_calls_flush(stream):
+    with mock.patch.object(stream, 'flush', create=True) as m:
+        StdStreamWriter(stream).close()
+        m.assert_called_once()
+
+
+def test_StdStreamWriter_close_does_not_call_close(stream):
+    with mock.patch.object(stream, 'close', create=True) as m:
+        StdStreamWriter(stream).close()
+        m.assert_not_called()
+
+
+def test_NamedPipe_makes_a_fifo():
+    path = '/tmp/foo.fifo'
+    with mock.patch('girder_worker.docker.io.os.mkfifo') as m:
+        NamedPipe(path)
+        m.assert_called_once_with(path)
+
+
+def test_NamedPipe_throws_exception_for_missing_fifo_path(tmpdir):
+    path = str(tmpdir.join('named_pipe.fifo'))
+
+    np = NamedPipe(path)
+
+    # Remove the FIFO
+    os.remove(path)
+
+    with pytest.raises(Exception):
+        np.open('FLAGS')
+
+
+def test_NamedPipe_throws_exception_for_non_fifo_path(tmpdir):
+    path = str(tmpdir.join('named_pipe.fifo'))
+
+    np = NamedPipe(path)
+
+    # Remove the FIFO
+    os.remove(path)
+
+    # Create a regular File
+    with open(path, 'w') as fh:
+        fh.write('Test Data')
+
+    with pytest.raises(Exception):
+        np.open('FLAGS')
+
+
+def test_NamedPipe_throws_exception_for_non_readable_path(tmpdir):
+    path = str(tmpdir.join('named_pipe.fifo'))
+
+    np = NamedPipe(path)
+
+    # permissions: --w--w----
+    os.chmod(path, 0220)
+
+    with pytest.raises(Exception):
+        np.open(os.O_RDONLY)
+
+
+def test_NamedPipe_open_calls_os_open_on_path(tmpdir):
+    path = str(tmpdir.join('named_pipe.fifo'))
+    np = NamedPipe(path)
+
+    with mock.patch('girder_worker.docker.io.os.open') as m:
+        np.open('FLAGS')
+        m.assert_called_once_with(path, 'FLAGS')
+
+
+def test_NamedPipeReader_open_calls_pipe_open(stream):
+    with mock.patch.object(stream, 'open', create=True) as m:
+        NamedPipeReader(stream).open()
+        m.assert_called_once()
+
+
+def test_NamedPipeReader_path_is_container_path(stream):
+    path = '/some/test/path/'
+    npr = NamedPipeReader(stream, container_path=path)
+    assert npr.path() == path
+
+
+def test_NamedPipeReader_fileno_is_pipe_fileno(stream):
+    npr = NamedPipeReader(stream)
+    assert npr.fileno() == stream.fileno()
+
+
+def test_NamedPipeWriter_open_calls_pipe_open(stream):
+    with mock.patch.object(stream, 'open', create=True) as m:
+        NamedPipeWriter(stream).open()
+        m.assert_called_once()
+
+
+def test_NamedPipeWriter_path_is_container_path(stream):
+    path = '/some/test/path/'
+    npr = NamedPipeWriter(stream, container_path=path)
+    assert npr.path() == path
+
+
+def test_NamedPipeWriter_fileno_is_pipe_fileno(stream):
+    npr = NamedPipeWriter(stream)
+    assert npr.fileno() == stream.fileno()
+
+
+def test_ChunkedTransferEncodingStreamWriter_https_creates_ssl_context():
+    with mock.patch('girder_worker.docker.io.httplib.HTTPSConnection', autospec=True):
+        with mock.patch('girder_worker.docker.io.ssl') as mock_ssl:
+            ChunkedTransferEncodingStreamWriter('https://bogus.url.com/')
+            mock_ssl.create_default_context.assert_called_once()
+
+
+def test_ChunkedTransferEncodingStreamWriter_transfer_encoding_in_headers():
+    with mock.patch('girder_worker.docker.io.httplib.HTTPConnection', autospec=True):
+        s = ChunkedTransferEncodingStreamWriter('http://bogus.url.com/')
+        s.conn.putheader.assert_called_with('Transfer-Encoding', 'chunked')
+
+
+def test_ChunkedTransferEncodingStreamWriter_custom_headers():
+    with mock.patch('girder_worker.docker.io.httplib.HTTPConnection', autospec=True):
+        s = ChunkedTransferEncodingStreamWriter('http://bogus.url.com/', headers={
+            'Key1': 'Value1',  'Key2': 'Value2'})
+        s.conn.putheader.assert_any_call('Key1', 'Value1')
+        s.conn.putheader.assert_any_call('Key2', 'Value2')
+
+
+def test_ChunkedTransferEncodingStreamWriter_write_sends_newline_separated_length_and_data():
+    data = b'BOGUS DATA'
+    with mock.patch('girder_worker.docker.io.httplib.HTTPConnection', autospec=True):
+        s = ChunkedTransferEncodingStreamWriter('http://bogus.url.com/')
+        s.write(data)
+        s.conn.send.assert_has_calls([
+            mock.call(hex(len(data))[2:].encode('utf-8')),
+            mock.call(b'\r\n'),
+            mock.call(data),
+            mock.call(b'\r\n')
+        ])
+
+
+def test_ChunkedTransferEncodingStreamWriter_write_on_exception_still_closes():
+    data = b'BOGUS DATA'
+    with mock.patch('girder_worker.docker.io.httplib.HTTPConnection', autospec=True):
+        s = ChunkedTransferEncodingStreamWriter('http://bogus.url.com/')
+        s.conn.send.side_effect = httplib.HTTPException('Bogus Exception')
+        with pytest.raises(httplib.HTTPException):
+            s.write(data)
+            s.conn.close.assert_called_once()
+            assert s._closed is True
+
+
+def test_ChunkedTransferEncodingStreamWriter_close_returns_if_already_closed():
+    with mock.patch('girder_worker.docker.io.httplib.HTTPConnection', autospec=True):
+        s = ChunkedTransferEncodingStreamWriter('http://bogus.url.com/')
+        s._closed = True
+        s.close()
+        # Nothing was sent
+        s.conn.send.assert_not_called()
+
+
+def test_ChunkedTransferEncodingStreamWriter_close_sends_empty_message():
+    with mock.patch('girder_worker.docker.io.httplib.HTTPConnection', autospec=True):
+        s = ChunkedTransferEncodingStreamWriter('http://bogus.url.com/')
+        with mock.patch.object(s.conn, 'getresponse', return_value=mock.MagicMock(status=200)):
+            s.close()
+            s.conn.send.assert_called_once_with(b'0\r\n\r\n')
+            s.conn.close.assert_called_once()
+
+
+@pytest.mark.parametrize('ec', [301, 302, 404, 405, 500])
+def test_ChunkedTransferEncodingStreamWriter_close_raises_exceptions_on_bad_http_codes(ec):
+    with mock.patch('girder_worker.docker.io.httplib.HTTPConnection', autospec=True):
+        s = ChunkedTransferEncodingStreamWriter('http://bogus.url.com/')
+        with mock.patch.object(s.conn, 'getresponse', return_value=mock.MagicMock(status=ec)):
+            with pytest.raises(Exception):
+                s.close()
+                s.conn.close.assert_called_once()
+
+
+def test_GirderFileStreamReader_calls_girder_client_downloadFileAsIterator():
+    mock_gc = mock.MagicMock(spec=GirderClient)
+
+    # Note: this is only nessisary until 2eb72df is released in girder-client
+    mock_gc.downloadFileAsIterator = mock.MagicMock()
+
+    mock_gc.downloadFileAsIterator.return_value = itertools.chain([b'1', b'2', b'3'])
+
+    gfsr = GirderFileStreamReader(mock_gc, -1)
+    gfsr.read(65536)
+    mock_gc.downloadFileAsIterator.assert_any_call(-1, 65536)
+
+
+def test_GirderFileStreamReader_returns_bytes_on_stop_iteration():
+    mock_gc = mock.MagicMock(spec=GirderClient)
+
+    # Note: this is only nessisary until 2eb72df is released in girder-client
+    mock_gc.downloadFileAsIterator = mock.MagicMock()
+
+    mock_gc.downloadFileAsIterator.return_value = itertools.chain([])
+
+    gfsr = GirderFileStreamReader(mock_gc, -1)
+    for b in gfsr.read(65536):
+        assert type(b, bytes)

--- a/tests/test_docker_nvidia.py
+++ b/tests/test_docker_nvidia.py
@@ -1,0 +1,78 @@
+import os
+import pytest
+import mock
+import requests
+
+from girder_worker.docker.nvidia import (
+    NVIDIA_DEFAULT_HOST,
+    NVIDIA_DEFAULT_PORT,
+    NvidiaAPIClient,
+    NvidiaConnectionError,
+    get_nvidia_docker_endpoint,
+    get_nvidia_configuration,
+    is_nvidia_image
+)
+
+
+def test_nvidia_docker_endpoint_returns_defaults():
+    assert get_nvidia_docker_endpoint() == \
+        'http://{}:{}/docker/cli/json'.format(NVIDIA_DEFAULT_HOST, NVIDIA_DEFAULT_PORT)
+
+
+def test_docker_endpoint_responds_to_NV_HOST(monkeypatch):
+    monkeypatch.setitem(os.environ, 'NV_HOST', 'http://bogus.com:8888')
+    assert get_nvidia_docker_endpoint() == 'http://bogus.com:8888/docker/cli/json'
+
+
+def test_get_nvidia_configuration_calls_docker_endpoint_url():
+    with mock.patch('girder_worker.docker.nvidia.requests.get') as m:
+        get_nvidia_configuration()
+        m.assert_called_with(get_nvidia_docker_endpoint())
+
+
+def test_get_nvidia_configuration_raises_NvidiaConnectionError_on_requests_ConnectionError():
+    with mock.patch('girder_worker.docker.nvidia.requests.get') as m:
+        m.side_effect = requests.exceptions.ConnectionError()
+        with pytest.raises(NvidiaConnectionError):
+            get_nvidia_configuration()
+
+
+def test_is_nvidia_image_no_labels_returns_false():
+    api = mock.MagicMock(spec=NvidiaAPIClient)
+    api.inspect_image.return_value = {}
+    assert is_nvidia_image(api, 'bogus/image:latest') is False
+
+
+def test_is_nvidia_image_no_nvidia_labels_returns_false():
+    api = mock.MagicMock(spec=NvidiaAPIClient)
+    api.inspect_image.return_value = {'Config': {'Labels': {'some': 'label'}}}
+    assert is_nvidia_image(api, 'bogus/image:latest') is False
+
+
+def test_is_nvidia_image_returns_true():
+    api = mock.MagicMock(spec=NvidiaAPIClient)
+    api.inspect_image.return_value = {'Config':
+                                      {'Labels':
+                                       {'com.nvidia.volumes.needed': 'nvidia_driver'}}}
+    assert is_nvidia_image(api, 'bogus/image:latest') is True
+
+
+def test_NvidiaAPIClient_create_container_config_is_nvidia_image_calls_add_nvidia_docker():
+    with mock.patch('girder_worker.docker.nvidia.APIClient.create_container_config'):
+        with mock.patch('girder_worker.docker.nvidia.is_nvidia_image', return_value=True):
+            with mock.patch('girder_worker.docker.nvidia.add_nvidia_docker_to_config') as m:
+                api = NvidiaAPIClient()
+                api.create_container_config('bogus/image:latest')
+                m.assert_called_once()
+
+
+def test_NvidiaAPIClient_create_container_config_is_nvidia_image_does_not_call_add_nvidia_docker():
+    with mock.patch('girder_worker.docker.nvidia.APIClient.create_container_config'):
+        with mock.patch('girder_worker.docker.nvidia.is_nvidia_image', return_value=False):
+            with mock.patch('girder_worker.docker.nvidia.add_nvidia_docker_to_config') as m:
+                api = NvidiaAPIClient()
+                api.create_container_config('bogus/image:latest')
+                m.assert_not_called()
+
+
+# TODO: add_nvidia_docker_to_config

--- a/tests/test_docker_stream_adapter.py
+++ b/tests/test_docker_stream_adapter.py
@@ -1,0 +1,69 @@
+import unittest
+from girder_worker.docker.stream_adapter import DockerStreamPushAdapter
+
+
+class CaptureAdapter(object):
+    def __init__(self):
+        self._captured = ''
+
+    def write(self, data):
+        self._captured += data
+
+    def captured(self):
+        return self._captured
+
+
+class TestDemultiplexerPushAdapter(unittest.TestCase):
+    def testSinglePayload(self):
+        data = [
+            '\x02\x00\x00\x00\x00\x00\x00\x14this is stderr data\n'
+        ]
+
+        capture = CaptureAdapter()
+        adapter = DockerStreamPushAdapter(capture)
+        for d in data:
+            adapter.write(d)
+
+        self.assertEqual(capture.captured(), 'this is stderr data\n')
+
+    def testAdapterBrokenUp(self):
+        data = [
+            '\x02\x00\x00\x00', '\x00\x00' '\x00\x14', 'this is stderr data\n'
+        ]
+
+        capture = CaptureAdapter()
+        adapter = DockerStreamPushAdapter(capture)
+        for d in data:
+            adapter.write(d)
+
+        self.assertEqual(capture.captured(), 'this is stderr data\n')
+
+    def testMultiplePayload(self):
+        data = [
+            '\x02\x00\x00\x00\x00\x00\x00\x14this is stderr data\n',
+            '\x01\x00\x00\x00\x00\x00\x00\x14this is stdout data\n',
+            '\x01\x00\x00\x00\x00\x00\x00\x0chello world!'
+        ]
+
+        capture = CaptureAdapter()
+        adapter = DockerStreamPushAdapter(capture)
+        for d in data:
+            adapter.write(d)
+
+        self.assertEqual(capture.captured(),
+                         'this is stderr data\nthis is stdout data\nhello world!')
+
+    def testMultiplePayloadOneRead(self):
+        data = [
+            '\x02\x00\x00\x00\x00\x00\x00\x14this is stderr data\n' +
+            '\x01\x00\x00\x00\x00\x00\x00\x14this is stdout data\n' +
+            '\x01\x00\x00\x00\x00\x00\x00\x0chello world!'
+        ]
+
+        capture = CaptureAdapter()
+        adapter = DockerStreamPushAdapter(capture)
+        for d in data:
+            adapter.write(d)
+
+        self.assertEqual(capture.captured(),
+                         'this is stderr data\nthis is stdout data\nhello world!')

--- a/tests/test_docker_tasks.py
+++ b/tests/test_docker_tasks.py
@@ -1,0 +1,53 @@
+import pytest
+
+from girder_worker.docker.tasks import ( # noqa F401
+    DockerTask,
+    _docker_run,
+    _handle_streaming_args,
+    _pull_image,
+    _run_container,
+    _run_select_loop,
+    docker_run
+)
+
+
+# TODO: test DockerTask
+@pytest.mark.skip
+def test_DockerTask():
+    pass
+
+
+# TODO: test _docker_run
+@pytest.mark.skip
+def test__docker_run():
+    pass
+
+
+# TODO: test _handle_streaming_args
+@pytest.mark.skip
+def test__handle_streaming_args():
+    pass
+
+
+# TODO: test _pull_image
+@pytest.mark.skip
+def test__pull_image():
+    pass
+
+
+# TODO: test _run_container
+@pytest.mark.skip
+def test__run_container():
+    pass
+
+
+# TODO: test _run_select_loop
+@pytest.mark.skip
+def test__run_select_loop():
+    pass
+
+
+# TODO: test docker_run
+@pytest.mark.skip
+def test_docker_run():
+    pass

--- a/tests/test_docker_transforms.py
+++ b/tests/test_docker_transforms.py
@@ -1,0 +1,230 @@
+import json
+import mock
+import pytest
+
+from girder_worker_utils.transform import Transform
+
+from girder_worker.docker.io import (
+    ChunkedTransferEncodingStreamWriter,
+    FDReadStreamConnector,
+    FDWriteStreamConnector,
+    NamedPipeReader,
+    NamedPipeWriter,
+    StdStreamWriter
+)
+
+from girder_worker.docker.transforms import (
+    ChunkedTransferEncodingStream,
+    Connect,
+    ContainerStdErr,
+    ContainerStdOut,
+    HostStdErr,
+    HostStdOut,
+    NamedInputPipe,
+    NamedOutputPipe,
+    NamedPipeBase,
+    TEMP_VOLUME_MOUNT_PREFIX,
+    TemporaryVolume,
+    Volume,
+    VolumePath,
+    _maybe_transform
+)
+
+
+def test_maybe_transform_transforms():
+    class T(Transform):
+        def transform(self, **kargs):
+            return 'FOOBAR'
+
+    assert _maybe_transform(T()) == 'FOOBAR'
+
+
+@pytest.mark.parametrize('obj', [
+    'string',
+    b'bytes',
+    1,
+    1.0,
+    {'key': 'value'},
+    ['some', 'list'],
+    ('tuple', ),
+    mock.Mock,
+    object()])
+def test_maybe_transform_passes_through(obj):
+    assert _maybe_transform(obj) == obj
+
+
+def test_HostStdOut_returns_StdStreamWriter():
+    assert isinstance(HostStdOut().transform(), StdStreamWriter)
+
+
+def test_HostStdErr_returns_StdStreamWriter():
+    assert isinstance(HostStdErr().transform(), StdStreamWriter)
+
+
+def test_ContainerStdOut_transform_retuns_self():
+    cso = ContainerStdOut()
+    assert cso.transform() == cso
+
+
+def test_ContainerStdErr_transform_retuns_self():
+    cse = ContainerStdErr()
+    assert cse.transform() == cse
+
+
+def test_Volume_container_path_is_container_path():
+    v = Volume('/bogus/host_path', '/bogus/container_path')
+    assert v.container_path == '/bogus/container_path'
+
+
+def test_Volume_host_path_is_host_path():
+    v = Volume('/bogus/host_path', '/bogus/container_path')
+    assert v.host_path == '/bogus/host_path'
+
+
+def test_Volume_transform_is_container_path():
+    v = Volume('/bogus/host_path/', '/bogus/container_path')
+    assert v.transform() == '/bogus/container_path'
+
+
+def test_Volume_repr_json_is_json_serializable():
+    v = Volume('/bogus/host_path/', '/bogus/container_path')
+    json.dumps(v._repr_json_())
+
+
+def test_TemporaryVolume_transform_creates_container_path():
+    with mock.patch('girder_worker.docker.transforms.uuid.uuid4',
+                    return_value=mock.Mock(hex='SOME_UUID')):
+        tv = TemporaryVolume()
+
+        assert tv.container_path is None
+        assert tv.transform() == '{}/SOME_UUID'.format(TEMP_VOLUME_MOUNT_PREFIX)
+        assert tv.container_path == '{}/SOME_UUID'.format(TEMP_VOLUME_MOUNT_PREFIX)
+
+
+def test_TemporaryVolume_host_path_is_temporary_directory():
+    with mock.patch('girder_worker.docker.transforms.tempfile.mkdtemp', return_value='/bogus/path'):
+        tv = TemporaryVolume()
+
+        assert tv.host_path is None
+        tv.transform()
+        assert tv.host_path == '/bogus/path'
+
+
+def test_TemporaryVolume_host_dir_prepended_to_host_path():
+    with mock.patch('girder_worker.docker.transforms.tempfile.mkdtemp') as mock_mkdtemp:
+        with mock.patch('girder_worker.docker.transforms.os.path.exists', return_value=True):
+            TemporaryVolume(host_dir='/some/preexisting/directory').transform()
+            mock_mkdtemp.assert_called_once_with(dir='/some/preexisting/directory')
+
+
+# TODO:  _DefaultTemporaryVolume and Metaclass behavior
+
+
+def test_NamedPipeBase_container_path_returns_container_path_plus_name():
+    npb = NamedPipeBase('test',
+                        container_path='/bogus/container_path',
+                        host_path='/bogus/host_path')
+
+    assert npb.container_path == '/bogus/container_path/test'
+
+
+def test_NamedPipeBase_host_path_returns_host_path_plus_name():
+    npb = NamedPipeBase('test',
+                        container_path='/bogus/container_path',
+                        host_path='/bogus/host_path')
+
+    assert npb.host_path == '/bogus/host_path/test'
+
+
+def test_NamedPipeBase_pass_volume_return_volume_container_path_plus_name():
+    v = Volume('/bogus/volume/host_path', '/bogus/volume/container_path')
+    npb = NamedPipeBase('test', volume=v)
+
+    assert npb.container_path == '/bogus/volume/container_path/test'
+
+
+def test_NamedPipeBase_pass_volume_return_volume_host_path_plus_name():
+    v = Volume('/bogus/volume/host_path', '/bogus/volume/container_path')
+    npb = NamedPipeBase('test', volume=v)
+
+    assert npb.host_path == '/bogus/volume/host_path/test'
+
+
+def test_NamedInputPipe_transform_returns_NamedPipeWriterr():
+    nip = NamedInputPipe('test',
+                         container_path='/bogus/container_path',
+                         host_path='/bogus/host_path')
+    with mock.patch('girder_worker.docker.io.os.mkfifo'):
+        assert isinstance(nip.transform(), NamedPipeWriter)
+
+
+def test_NamedOutputPipe_transform_returns_NamedPipeReader():
+    nop = NamedOutputPipe('test',
+                          container_path='/bogus/container_path',
+                          host_path='/bogus/host_path')
+    with mock.patch('girder_worker.docker.io.os.mkfifo'):
+        assert isinstance(nop.transform(), NamedPipeReader)
+
+
+def test_VolumePath_transform_returns_container_path_with_no_args():
+    v = Volume('/bogus/volume/host_path', '/bogus/volume/container_path')
+    vp = VolumePath('test', v)
+
+    assert vp.transform() == '/bogus/volume/container_path/test'
+
+
+def test_VolumePath_transform_returns_host_path_with_args():
+    v = Volume('/bogus/volume/host_path', '/bogus/volume/container_path')
+    vp = VolumePath('test', v)
+
+    assert vp.transform('TASK_DATA') == '/bogus/volume/host_path/test'
+
+
+def test_Connect_transform_returns_FDWriteStreamConnector_if_output_is_NamedInputPipe(istream):
+    nip_mock = mock.MagicMock(spec=NamedInputPipe(
+        'test',
+        container_path='/bogus/container_path',
+        host_path='/bogus/host_path'))
+    connection = Connect(istream, nip_mock)
+    assert isinstance(connection.transform(), FDWriteStreamConnector)
+
+
+def test_Connect_transform_returns_FDReadStreamConnector_if_input_is_NamedOutputPipe(ostream):
+    nop_mock = mock.MagicMock(spec=NamedOutputPipe(
+        'test',
+        container_path='/bogus/container_path',
+        host_path='/bogus/host_path'))
+    connection = Connect(nop_mock, ostream)
+    assert isinstance(connection.transform(), FDReadStreamConnector)
+
+
+def test_Connect_transform_throws_exception_if_no_NamedPipe_provided(istream, ostream):
+    with pytest.raises(TypeError):
+        Connect(istream, ostream).transform()
+
+
+def test_ChunkedTransferEncodingStream_transform_returns_ChunkedTransferEncodingStreamWriter():
+    ctes = ChunkedTransferEncodingStream('http://bogusurl.com')
+    with mock.patch('girder_worker.docker.io.httplib.HTTPConnection', autospec=True):
+        assert isinstance(ctes.transform(), ChunkedTransferEncodingStreamWriter)
+
+
+def test_ChunkedTransferEncodingStream_transform_calls_ChunkedTransferEncodingWriter_with_args():
+    ctes = ChunkedTransferEncodingStream('http://bogusurl.com')
+    with mock.patch('girder_worker.docker.io.ChunkedTransferEncodingStreamWriter',
+                    spec=True) as ctesw_class_mock:
+        ctes.transform()
+        ctesw_class_mock.assert_called_once_with('http://bogusurl.com', {})
+
+
+def test_ChunkedTransferEncodingStream_transform_calls_ChunkedTransferEncodingWriter_with_headers():
+    ctes = ChunkedTransferEncodingStream(
+        'http://bogusurl.com',
+        {'Key1': 'Value1', 'Key2': 'Value2'})
+
+    with mock.patch('girder_worker.docker.io.ChunkedTransferEncodingStreamWriter',
+                    spec=True) as ctesw_class_mock:
+        ctes.transform()
+        ctesw_class_mock.assert_called_once_with(
+            'http://bogusurl.com',
+            {'Key1': 'Value1', 'Key2': 'Value2'})

--- a/tests/test_docker_utils.py
+++ b/tests/test_docker_utils.py
@@ -1,0 +1,18 @@
+import pytest
+
+from girder_worker.docker.utils import ( # noqa F401
+    select_loop,
+    chmod_writable
+)
+
+
+# TODO: test select_loop
+@pytest.mark.skip
+def test_select_loop():
+    pass
+
+
+# TODO; test chmod_writable
+@pytest.mark.skip
+def test_chmod_writable():
+    pass


### PR DESCRIPTION
We can do better! Mostly hoping to improve test coverage of ```girder_worker/app.py``` and ```girder_worker/docker/*``` code. 

```
Name                                          Stmts   Miss  Cover
-----------------------------------------------------------------
girder_worker/__init__.py                        20      0   100%
girder_worker/__main__.py                        15      3    80%
girder_worker/app.py                            217     84    61%
girder_worker/celeryconfig.py                    11      0   100%
girder_worker/configure.py                       44      1    98%
girder_worker/docker/__init__.py                  6      0   100%
girder_worker/docker/io/__init__.py             168     72    57%
girder_worker/docker/io/girder.py                15     15     0%
girder_worker/docker/nvidia.py                   52     52     0%
girder_worker/docker/stream_adapter.py           37     37     0%
girder_worker/docker/tasks/__init__.py          186    186     0%
girder_worker/docker/transforms/__init__.py     150    150     0%
girder_worker/docker/transforms/girder.py        43     43     0%
girder_worker/docker/utils.py                    46     46     0%
girder_worker/entrypoint.py                      78      5    94%
girder_worker/log_utils.py                       15      1    93%
girder_worker/utils.py                          105     41    61%
-----------------------------------------------------------------
TOTAL                                          1208    736    39%
```

This is currently based on https://github.com/girder/girder_worker/pull/225