### PR TITLE
Remove references to girder_worker.core in docker module

### DIFF
--- a/girder_worker/docker/transforms/girder.py
+++ b/girder_worker/docker/transforms/girder.py
@@ -22,14 +22,12 @@ class ProgressPipe(Transform):
         self._volume = volume
 
     def transform(self, task=None, **kwargs):
-        from girder_worker.core.utils import JobProgressAdapter
+        from girder_worker.docker.stream_adapter import JobProgressAdapter
 
         self._volume.transform(**kwargs)
 
         # TODO What do we do is job_manager is None? When can it me None?
         job_mgr = task.job_manager
-        # For now we are using JobProgressAdapter which is part of core, we should
-        # probably add a copy to the docker package to break to reference to core.
         return Connect(NamedOutputPipe(self.name, self._volume),
                        JobProgressAdapter(job_mgr)).transform(**kwargs)
 


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/girder/girder_worker/pull/201

We need to maintain strict separation between girder_worker/core and girder_worker/ While this means copying code,  it's code that is likely to change in response to the needs of girder_worker/  (e.g. python 2/3 compatibility)