### PR TITLE
Set the test infrastructure socket host to 0.0.0.0

### DIFF
--- a/tests/integration/scripts/setup.yml
+++ b/tests/integration/scripts/setup.yml
@@ -19,6 +19,14 @@
         editable: true
 
 
+    # Note that this will force a server restart
+    - name: Set the server.socket_host to 0.0.0.0
+      lineinfile:
+        path: /girder/girder/conf/girder.local.cfg
+        regexp: '^server.socket_host'
+        line: 'server.socket_host = "0.0.0.0"'
+
+
     - name: Wait Girder to come up
       wait_for:
         port: "{{ girder_port }}"


### PR DESCRIPTION
Without this girder binds to 127.0.0.1 which does not forward through
the container and makes girder inaccessible to girder_worker (and the
host).