### PR TITLE
Raise exception if docker exits with non-zero code

### DIFF
--- a/girder_worker/docker/tasks/__init__.py
+++ b/girder_worker/docker/tasks/__init__.py
@@ -149,6 +149,10 @@ def _run_select_loop(task, container, read_stream_connectors, write_stream_conne
                 logger.error(dex)
                 raise
 
+        container.reload()
+        exit_code = container.attrs['State']['ExitCode']
+        if exit_code != 0:
+            raise DockerException('Non-zero exit code from docker container (%d).' % exit_code)
     finally:
         # Close our stdout and stderr sockets
         if stdout:

--- a/girder_worker/plugins/docker/tests/docker_test.py
+++ b/girder_worker/plugins/docker/tests/docker_test.py
@@ -28,6 +28,9 @@ stderr_socket_mock.fileno.return_value = ERR_FD
 docker_container_mock = mock.Mock()
 docker_container_mock.attach_socket.side_effect = [stdout_socket_mock, stderr_socket_mock]
 docker_container_mock.status = 'exited'
+docker_container_mock.attrs = {
+    'State': {'ExitCode': 0}
+}
 
 docker_client_mock = mock.Mock()
 docker_client_mock.containers.run = mock.Mock(return_value=docker_container_mock)

--- a/tests/integration/fixtures/docker_test_image/test.py
+++ b/tests/integration/fixtures/docker_test_image/test.py
@@ -77,5 +77,10 @@ def print_path(p):
     print(p)
 
 
+@cli.command()
+def raise_exception():
+    raise Exception('girder docker exception')
+
+
 if __name__ == '__main__':
     cli(obj={})

--- a/tests/integration/integration_test_endpoints/server/docker.py
+++ b/tests/integration/integration_test_endpoints/server/docker.py
@@ -63,6 +63,8 @@ class DockerTestEndpoints(Resource):
                    self.test_docker_run_transfer_encoding_stream)
         self.route('POST', ('test_docker_run_temporary_volume_root', ),
                    self.test_docker_run_temporary_volume_root)
+        self.route('POST', ('test_docker_run_raises_exception', ),
+                   self.test_docker_run_raises_exception)
 
     @access.token
     @filtermodel(model='job', plugin='jobs')
@@ -73,6 +75,15 @@ class DockerTestEndpoints(Resource):
             TEST_IMAGE, pull_image=True, container_args=['stdio', '-m', 'hello docker!'],
             remove_container=True)
 
+        return result.job
+
+    @access.token
+    @filtermodel(model='job', plugin='jobs')
+    @describeRoute(
+        Description('Test docker run that raises an exception.'))
+    def test_docker_run_raises_exception(self, params):
+        result = docker_run.delay(
+            TEST_IMAGE, pull_image=True, container_args=['raise_exception'], remove_container=True)
         return result.job
 
     @access.token

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -5,6 +5,28 @@ import json
 from girder_worker.utils import JobStatus
 import pytest
 
+FIXTURE_DIR = os.path.join('..', os.path.dirname(__file__), 'fixtures')
+
+
+def _assert_job_statuses(job):
+    assert [ts['status'] for ts in job['timestamps']] == [JobStatus.RUNNING, JobStatus.SUCCESS]
+
+
+def _assert_job_contents(r, session, test_file, remove_newline=True):
+    assert r.status_code == 200, r.content
+
+    with session.wait_for_success(r.json()['_id']) as job:
+        _assert_job_statuses(job)
+
+        # Remove escaped chars
+        log = ''.join(str(l) for l in job['log'])
+        # Remove trailing \n added by test script
+        if remove_newline:
+            log = log[:-1]
+
+        with open(test_file) as fp:
+            assert log == fp.read()
+
 
 @pytest.mark.docker
 def test_docker_run(session):
@@ -12,33 +34,20 @@ def test_docker_run(session):
     assert r.status_code == 200, r.content
 
     with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
-
-        log = job['log']
-        assert len(log) == 1
-        assert log[0] == 'hello docker!\n'
+        _assert_job_statuses(job)
+        assert job['log'] == ['hello docker!\n']
 
 
 @pytest.mark.docker
-def test_docker_run_volume(session):
-    fixture_dir = os.path.join('..', os.path.dirname(__file__), 'fixtures')
-    params = {
-        'fixtureDir': fixture_dir
-    }
-    r = session.post('integration_tests/docker/test_docker_run_mount_volume',
-                     params=params)
-    assert r.status_code == 200, r.content
-
-    with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
-
-        log = job['log']
-        assert len(log) == 1
-        filepath = os.path.join(fixture_dir, 'read.txt')
-        with open(filepath) as fp:
-            assert log[0] == '%s\n' % fp.read()
+@pytest.mark.parametrize('url', [
+    'integration_tests/docker/test_docker_run_mount_volume',
+    'integration_tests/docker/test_docker_run_mount_idiomatic_volume'
+])
+def test_docker_run_volumes(url, session):
+    r = session.post(url, params={
+        'fixtureDir': FIXTURE_DIR
+    })
+    _assert_job_contents(r, session, os.path.join(FIXTURE_DIR, 'read.txt'))
 
 
 @pytest.mark.docker
@@ -47,46 +56,28 @@ def test_docker_run_named_pipe_output(session, all_writable_tmpdir):
         'tmpDir': all_writable_tmpdir,
         'message': 'Dydh da'
     }
-    r = session.post('integration_tests/docker/test_docker_run_named_pipe_output',
-                     params=params)
+    r = session.post('integration_tests/docker/test_docker_run_named_pipe_output', params=params)
     assert r.status_code == 200, r.content
 
     with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
-
-        log = job['log']
-        assert len(log) == 1
-        assert log[0] == params['message']
+        _assert_job_statuses(job)
+        assert job['log'] == [params['message']]
 
 
 @pytest.mark.docker
-def test_docker_run_girder_file_to_named_pipe(session, test_file, test_file_in_girder,
-                                              all_writable_tmpdir):
-
+def test_docker_run_girder_file_to_named_pipe(
+        session, test_file, test_file_in_girder, all_writable_tmpdir):
     params = {
         'tmpDir': all_writable_tmpdir,
         'fileId': test_file_in_girder['_id']
     }
-    r = session.post('integration_tests/docker/test_docker_run_girder_file_to_named_pipe',
-                     params=params)
-    assert r.status_code == 200, r.content
-
-    with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
-
-        # Remove escaped chars
-        log = [str(l) for l in job['log']]
-        # join and remove trailing \n added by test script
-        log = ''.join(log)[:-1]
-        with open(test_file) as fp:
-            assert log == fp.read()
+    r = session.post(
+        'integration_tests/docker/test_docker_run_girder_file_to_named_pipe', params=params)
+    _assert_job_contents(r, session, test_file)
 
 
 @pytest.mark.docker
 def test_docker_run_file_upload_to_item(session, girder_client, test_item):
-
     contents = b'Balaenoptera musculus'
     params = {
         'itemId': test_item['_id'],
@@ -97,8 +88,7 @@ def test_docker_run_file_upload_to_item(session, girder_client, test_item):
     assert r.status_code == 200, r.content
 
     with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
+        _assert_job_statuses(job)
 
     files = list(girder_client.listFile(test_item['_id']))
 
@@ -112,51 +102,15 @@ def test_docker_run_file_upload_to_item(session, girder_client, test_item):
 
 
 @pytest.mark.docker
-def test_docker_run_girder_file_to_named_pipe_on_temp_vol(session, test_file, test_file_in_girder):
-    """
-    This is a simplified version of test_docker_run_girder_file_to_named_pipe
-    it uses the TemporaryVolume, rather than having to setup the volumes
-    'manually', this is the approach we should encourage.
-    """
-
-    params = {
+@pytest.mark.parametrize('url,strip_lf', [
+    ('integration_tests/docker/test_docker_run_girder_file_to_named_pipe_on_temp_vol', True),
+    ('integration_tests/docker/test_docker_run_girder_file_to_volume', False)
+])
+def test_docker_run_girder_file(url, strip_lf, session, test_file, test_file_in_girder):
+    r = session.post(url, params={
         'fileId': test_file_in_girder['_id']
-    }
-    url = 'integration_tests/docker/test_docker_run_girder_file_to_named_pipe_on_temp_vol'
-    r = session.post(url, params=params)
-    assert r.status_code == 200, r.content
-
-    with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
-
-        # Remove escaped chars
-        log = [str(l) for l in job['log']]
-        # join and remove trailing \n added by test script
-        log = ''.join(log)[:-1]
-        with open(test_file) as fp:
-            assert log == fp.read()
-
-
-@pytest.mark.docker
-def test_docker_run_idiomatic_volume(session):
-    fixture_dir = os.path.join('..', os.path.dirname(__file__), 'fixtures')
-    params = {
-        'fixtureDir': fixture_dir
-    }
-    r = session.post('integration_tests/docker/test_docker_run_mount_idiomatic_volume',
-                     params=params)
-    assert r.status_code == 200, r.content
-
-    with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
-
-        log = job['log']
-        assert len(log) == 1
-        filepath = os.path.join(fixture_dir, 'read.txt')
-        with open(filepath) as fp:
-            assert log[0] == '%s\n' % fp.read()
+    })
+    _assert_job_contents(r, session, test_file, remove_newline=strip_lf)
 
 
 @pytest.mark.docker
@@ -173,33 +127,12 @@ def test_docker_run_progress_pipe(session):
     assert r.status_code == 200, r.content
 
     with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
+        _assert_job_statuses(job)
 
         progress = job['progress']
 
         del progress['notificationId']
         assert progress == progressions[-1]
-
-
-@pytest.mark.docker
-def test_docker_run_girder_file_to_volume(session, test_file, test_file_in_girder):
-    params = {
-        'fileId': test_file_in_girder['_id']
-    }
-    r = session.post('integration_tests/docker/test_docker_run_girder_file_to_volume',
-                     params=params)
-    assert r.status_code == 200, r.content
-
-    with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
-
-        # Remove escaped chars
-        log = [str(l) for l in job['log']]
-        log = ''.join(log)
-        with open(test_file) as fp:
-            assert log == fp.read()
 
 
 @pytest.mark.docker
@@ -216,8 +149,7 @@ def test_docker_run_transfer_encoding_stream(session, girder_client, test_file,
     assert r.status_code == 200, r.content
 
     with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
+        _assert_job_statuses(job)
 
     files = list(girder_client.listFile(test_item['_id']))
 
@@ -227,7 +159,7 @@ def test_docker_run_transfer_encoding_stream(session, girder_client, test_file,
     girder_client.downloadFile(files[0]['_id'], file_contents)
     file_contents.seek(0)
     chunks = file_contents.read().split(delimiter)
-    chunks = [c for c in chunks if c != '']
+    chunks = [c for c in chunks if c]
 
     # We should have at least 4 chunks
     assert len(chunks) >= 4
@@ -238,14 +170,11 @@ def test_docker_run_transfer_encoding_stream(session, girder_client, test_file,
 
 @pytest.mark.docker
 def test_docker_run_temporary_volume_root(session):
-    params = {
+    r = session.post('integration_tests/docker/test_docker_run_temporary_volume_root', params={
         'prefix': 'prefix'
-    }
-    r = session.post('integration_tests/docker/test_docker_run_temporary_volume_root',
-                     params=params)
+    })
     assert r.status_code == 200, r.content
 
     with session.wait_for_success(r.json()['_id']) as job:
-        assert [ts['status'] for ts in job['timestamps']] == \
-            [JobStatus.RUNNING, JobStatus.SUCCESS]
+        _assert_job_statuses(job)
         assert len(job['log']) == 1

--- a/tests/integration/test_docker.py
+++ b/tests/integration/test_docker.py
@@ -178,3 +178,14 @@ def test_docker_run_temporary_volume_root(session):
     with session.wait_for_success(r.json()['_id']) as job:
         _assert_job_statuses(job)
         assert len(job['log']) == 1
+
+
+@pytest.mark.docker
+def test_docker_run_bad_exit_code(session):
+    r = session.post('integration_tests/docker/test_docker_run_raises_exception')
+    assert r.status_code == 200, r.content
+    with session.wait_for_success(r.json()['_id']) as job:
+        log = ''.join(job['log'])
+        assert job['status'] == JobStatus.ERROR
+        assert 'girder docker exception' in log
+        assert 'Non-zero exit code from docker container' in log


### PR DESCRIPTION
Here's a candidate solution to #249 . I'm not sure how it interacts with job cancellation or other odd circumstances surrounding docker container execution, but it works in the case of the container returning normally with non-zero.