### PR TITLE
Never list "core" as an installed plugin on python 3

### DIFF
--- a/girder_worker/__main__.py
+++ b/girder_worker/__main__.py
@@ -1,4 +1,3 @@
-import six
 from six.moves.configparser import NoSectionError, NoOptionError
 
 from . import config
@@ -7,14 +6,11 @@ from .entrypoint import get_core_task_modules, get_plugin_task_modules
 
 
 def main():
-    if six.PY2:
-        try:
-            include_core_tasks = config.getboolean(
-                'girder_worker', 'core_tasks')
-        except (NoSectionError, NoOptionError):
-            include_core_tasks = True
-    else:
-        include_core_tasks = False
+    try:
+        include_core_tasks = config.getboolean(
+            'girder_worker', 'core_tasks')
+    except (NoSectionError, NoOptionError):
+        include_core_tasks = True
 
     if include_core_tasks:
         app.conf.update({

--- a/girder_worker/entrypoint.py
+++ b/girder_worker/entrypoint.py
@@ -56,9 +56,13 @@ def get_task_imports(ext):
     return includes
 
 
+# Core tasks are only supported on python 2.  When running in python 3
+# this always returns an empty list to avoid loading `girder_worker.core`.
 def get_core_task_modules(app=None):
     """Return task modules defined by core."""
-    return get_task_imports(get_extension_manager(app=app)['core'])
+    if six.PY2:
+        return get_task_imports(get_extension_manager(app=app)['core'])
+    return []
 
 
 def get_plugin_task_modules(app=None):
@@ -81,8 +85,14 @@ def import_all_includes(core=True):
 
 
 def get_extensions(app=None):
-    """Get a list of install extensions."""
-    return [ext.name for ext in get_extension_manager(app)] + list(_extensions.keys())
+    """Get a list of installed extensions."""
+    extensions = [ext.name for ext in get_extension_manager(app)] + list(_extensions.keys())
+
+    # Because the "core" entrypoint is installed with girder_worker, we have
+    # to manually exclude it from the list of extensions when not on python 2.
+    if not six.PY2:
+        extensions = list(filter(lambda extension: extension != 'core', extensions))
+    return extensions
 
 
 def get_module_tasks(module_name):


### PR DESCRIPTION
Before this change when trying to do task discovery when running python
3, the "core" plugin was always listed and imported regardless of the
configuration option.  This change removes "core" entirely from the plugin
list when not running in python 2.