### PR TITLE
Use cherrypy.request.app to determine producer/consumer context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added Features
 Bug fixes
 ---------
 
+* Use cherrypy.request.app instead of ImportException to determine signal context (`#275 <https://github.com/girder/girder_worker/pull/275>`_)
+
 Changes
 -------
 

--- a/girder_worker/context/__init__.py
+++ b/girder_worker/context/__init__.py
@@ -3,15 +3,10 @@ from . import girder_context, nongirder_context
 
 def get_context():
     try:
-        # Note: If we can import these objects from the girder packages we
-        # assume our producer is in a girder REST request. This allows
-        # us to create the job model's directly. Otherwise there will be an
-        # ImportError and we can create the job via a REST request using
-        # the jobInfoSpec in headers.
-
-        from girder.utility.model_importer import ModelImporter # noqa
-        from girder.plugins.worker import utils # noqa
-        from girder.api.rest import getCurrentUser # noqa
-        return girder_context
+        import cherrypy
+        if cherrypy.request.app is None:
+            return nongirder_context
+        else:
+            return girder_context
     except ImportError:
         return nongirder_context

--- a/tests/task_signal_test.py
+++ b/tests/task_signal_test.py
@@ -74,9 +74,9 @@ class TestSignals(unittest.TestCase):
                       headers=self.headers)
 
         create_job = mi.model.return_value.createJob
-
-        with mock_worker_plugin_utils():
-            girder_before_task_publish(**inputs)
+        with mock.patch('cherrypy.request.app', return_value=True):
+            with mock_worker_plugin_utils():
+                girder_before_task_publish(**inputs)
 
         gcu.assert_called_once()
         self.assertTrue(not create_job.called)
@@ -91,9 +91,9 @@ class TestSignals(unittest.TestCase):
                       headers={'id': 'CELERY-ASYNCRESULT-ID'})
 
         create_job = mi.model.return_value.createJob
-
-        with mock_worker_plugin_utils():
-            girder_before_task_publish(**inputs)
+        with mock.patch('cherrypy.request.app', return_value=True):
+            with mock_worker_plugin_utils():
+                girder_before_task_publish(**inputs)
 
         # gcu.assert_called_once()
         create_job.assert_called_once_with(
@@ -121,9 +121,9 @@ class TestSignals(unittest.TestCase):
                                'girder_job_other_fields': {'SOME_OTHER': 'FIELD'}})
 
         create_job = mi.model.return_value.createJob
-
-        with mock_worker_plugin_utils():
-            girder_before_task_publish(**inputs)
+        with mock.patch('cherrypy.request.app', return_value=True):
+            with mock_worker_plugin_utils():
+                girder_before_task_publish(**inputs)
 
         # gcu.assert_called_once()
         create_job.assert_called_once_with(
@@ -146,11 +146,12 @@ class TestSignals(unittest.TestCase):
                       body=[(), {}, {}],
                       headers={'id': 'CELERY-ASYNCRESULT-ID'})
 
-        with mock_worker_plugin_utils() as utils:
-            girder_before_task_publish(**inputs)
+        with mock.patch('cherrypy.request.app', return_value=True):
+            with mock_worker_plugin_utils() as utils:
+                girder_before_task_publish(**inputs)
 
-            utils.jobInfoSpec.asset_called_once()
-            utils.getWorkerApiUrl.assert_called_once()
+                utils.jobInfoSpec.asset_called_once()
+                utils.getWorkerApiUrl.assert_called_once()
 
     @mock.patch('girder_worker.utils.JobManager')
     def test_task_prerun(self, jm):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -79,15 +79,16 @@ def test_GirderAsyncResult_job_property_returns_None_on_ImportError():
 def test_GirderAsyncResult_job_property_calls_findOne_on_girder_job_model():
     gar = GirderAsyncResult('BOGUS_TASK_ID')
 
-    with mock.patch.dict('sys.modules',
-                         **{'girder.plugins': mock.MagicMock(),
-                            'girder.plugins.worker': mock.MagicMock(),
-                            'girder.plugins.worker.utils': mock.MagicMock()}):
-        with mock.patch('girder.utility.model_importer.ModelImporter') as mi:
-            gar.job
-            mi.model.return_value.findOne.assert_called_once_with({
-                'celeryTaskId': 'BOGUS_TASK_ID'
-            })
+    with mock.patch('cherrypy.request.app', return_value=True):
+        with mock.patch.dict('sys.modules',
+                             **{'girder.plugins': mock.MagicMock(),
+                                'girder.plugins.worker': mock.MagicMock(),
+                                'girder.plugins.worker.utils': mock.MagicMock()}):
+            with mock.patch('girder.utility.model_importer.ModelImporter') as mi:
+                gar.job
+                mi.model.return_value.findOne.assert_called_once_with({
+                    'celeryTaskId': 'BOGUS_TASK_ID'
+                })
 
 
 def test_GirderAsyncResult_job_property_returns_None_if_no_jobs_found():


### PR DESCRIPTION
Should fix https://github.com/girder/girder_worker/issues/274