### PR TITLE
Move task discovery out of __main__ into app initialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changes
 
 * Volume transforms renamed to BindMountVolume (`#273 <https://github.com/girder/girder_worker/pull/273>`_)
 * Refactor signals to introduce 'context' in which code is being executed (`#271 <https://github.com/girder/girder_worker/pull/271>`_)
+* Move entrypoint based task descovery earlier in application initialization (`#271 <https://github.com/girder/girder_worker/pull/278?`_)
 
 
 Deprecations

--- a/girder_worker/__main__.py
+++ b/girder_worker/__main__.py
@@ -1,25 +1,7 @@
-from six.moves.configparser import NoSectionError, NoOptionError
-
-from . import config
 from .app import app
-from .entrypoint import get_core_task_modules, get_plugin_task_modules
 
 
 def main():
-    try:
-        include_core_tasks = config.getboolean(
-            'girder_worker', 'core_tasks')
-    except (NoSectionError, NoOptionError):
-        include_core_tasks = True
-
-    if include_core_tasks:
-        app.conf.update({
-            'CELERY_IMPORTS': get_core_task_modules()
-        })
-
-    app.conf.update({
-        'CELERY_INCLUDE': get_plugin_task_modules()
-    })
     app.worker_main()
 
 

--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -19,7 +19,9 @@ from girder_client import GirderClient
 
 import girder_worker
 from girder_worker import logger
+from girder_worker import config
 from girder_worker.context import get_context
+from girder_worker.entrypoint import discover_tasks
 from girder_worker.task import Task
 from girder_worker.utils import (
     JobSpecNotFound,
@@ -34,6 +36,7 @@ import jsonpickle
 from kombu.serialization import register
 
 import six
+from six.moves.configparser import NoOptionError, NoSectionError
 
 
 @before_task_publish.connect  # noqa: C901
@@ -211,3 +214,12 @@ app = Celery(
     task_cls='girder_worker.task:Task')
 
 app.config_from_object('girder_worker.celeryconfig')
+
+try:
+    include_core_tasks = config.getboolean(
+        'girder_worker', 'core_tasks')
+except (NoSectionError, NoOptionError):
+    include_core_tasks = True
+
+
+discover_tasks(app, core=include_core_tasks)

--- a/girder_worker/entrypoint.py
+++ b/girder_worker/entrypoint.py
@@ -1,9 +1,11 @@
 from importlib import import_module
-
-from girder_worker_utils import decorators
-import six
-from stevedore import extension
 import celery
+from girder_worker_utils import decorators
+
+import six
+
+from stevedore import extension
+
 
 #: Defines the namespace used for plugin entrypoints
 NAMESPACE = 'girder_worker_plugins'
@@ -163,3 +165,14 @@ def register_extension(name, tasks):
     """
     global _extensions
     _extensions[name] = tasks
+
+
+def discover_tasks(app, core=True):
+    if core:
+        app.conf.update({
+            'CELERY_IMPORTS': get_core_task_modules()
+        })
+
+    app.conf.update({
+        'CELERY_INCLUDE': get_plugin_task_modules()
+    })

--- a/tests/task_plugin_test.py
+++ b/tests/task_plugin_test.py
@@ -3,6 +3,7 @@ import re
 from girder_worker import entrypoint
 from girder_worker.__main__ import main
 from girder_worker.app import app
+from girder_worker.entrypoint import discover_tasks
 
 from girder_worker_utils import decorators
 from girder_worker_utils import types
@@ -68,16 +69,16 @@ def test_invalid_plugins(capsys):
 
 @pytest.mark.skipif(six.PY3, reason='Python 2 only')
 def test_core_plugin():
-    with mock.patch('girder_worker.__main__.app') as app:
-        main()
+    with mock.patch('girder_worker.app.app') as app:
+        discover_tasks(app, True)
         app.conf.update.assert_any_call({'CELERY_IMPORTS':
                                          ['girder_worker.tasks']})
 
 
 @pytest.mark.namespace('girder_worker._test_plugins.valid_plugins')
 def test_external_plugins():
-    with mock.patch('girder_worker.__main__.app') as app:
-        main()
+    with mock.patch('girder_worker.app.app') as app:
+        discover_tasks(app, True)
         if six.PY2:
             app.conf.update.assert_any_call({'CELERY_IMPORTS':
                                              ['os.path']})


### PR DESCRIPTION
While this is a small code change it's actually potentially a pretty big functionality change.

What this PR enables,  is the ability to use celery "as intended"  on the command line.  While ```girder-worker -l info```  still works,  this also supports running girder worker as ```celery worker -A girder-worker.app -l info ...```.  This is important because celery offers a number of other commands we might be interested in supporting/using in production environments including flower,  events,  inspect, control, among others. 

The primary thing preventing us from using those was task discovery (via entrypoints)  happening in the ```main()``` function  and not as apart of the import side-effects of the app module (which is what implicitly celery expects). 

This has some positive side effects. It resolves a lurking issue on the producer side,  where ```girder_worker.app.app``` was not being initialized with all the installed tasks,  but instead had tasks added to it as your imported them into the running girder instance For example ```from my_packagbe.tasks import my_task```.  Because my_task is wrapped by ```@app.task(...)``` it was being added to the internal ```app._tasks``` mapping at import time. But what this means is that ```app._tasks``` only reflects the imported tasks across all plugins/handlers/etc **not** the tasks that are actually pip installed inside the environment.  Most of the time that difference doesn't functionally matter,  but it is still unpleasantly confusing.  This resolves that issue,  but at the risk of surfacing other problems on the producer that were hidden until now. 

@zachmullen could you take a look in the context of the AaaS stuff? @cjh1's input would also be very welcome!

