### PR TITLE
Stop serializing builtin tasks with jsonpickle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Added Features
 Bug fixes
 ---------
 
-* Resolve issue with breaking chords (`#280 <https://github.com/girder/girder_worker/pull/280>`_)
+* Resolve multiple issues related to broken chord functionality
+  (`#280 <https://github.com/girder/girder_worker/pull/280>`_, `#282 <https://github.com/girder/girder_worker/pull/282>`_)
 * Use cherrypy.request.app instead of ImportException to determine signal context (`#275 <https://github.com/girder/girder_worker/pull/275>`_)
 
 Changes

--- a/girder_worker/celeryconfig.py
+++ b/girder_worker/celeryconfig.py
@@ -3,8 +3,6 @@ from six.moves import configparser
 import girder_worker
 
 accept_content = ['json', 'pickle', 'yaml', 'girder_io']
-task_serializer = 'girder_io'
-result_serializer = 'girder_io'
 
 broker_url = os.environ.get('GIRDER_WORKER_BROKER', None) or \
     girder_worker.config.get('celery', 'broker')

--- a/girder_worker/task.py
+++ b/girder_worker/task.py
@@ -104,7 +104,7 @@ class Task(celery.Task):
 
         return super(Task, self).apply_async(
             args=args, kwargs=kwargs, task_id=task_id, producer=producer,
-            link=link, link_error=link_error, shadow=shadow, **options)
+            link=link, link_error=link_error, shadow=shadow, serializer='girder_io', **options)
 
     @property
     def canceled(self):


### PR DESCRIPTION
This commit removes girder_io as the default serialization mechanism
because it does not support serializing return values from built in
celery tasks such as chord_unlock.

Usage of the serializer kwarg in our overriden apply_async allows us
to only use girder_io (jsonpickle) on custom tasks.