### PR TITLE
Add support for serializing/deserializing numpy arrays

### DIFF
--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -35,6 +35,9 @@ from girder_worker.utils import (
 )
 
 import jsonpickle
+import jsonpickle.ext.numpy as jsonpickle_numpy
+jsonpickle_numpy.register_handlers()
+
 from kombu.serialization import register
 
 import six


### PR DESCRIPTION
This operation can be very slow for large arrays.  Mileage may vary.