### PR TITLE
Avoid celery version 4.2.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-celery>=4
+celery>=4,<4.2
 funcsigs ; python_version < '3.3'
 girder-client>=2
 networkx<2


### PR DESCRIPTION
Celery version 4.2 frequently throws a `Errno 104: Connection reset by peer` when communicating with RabbitMQ.  See https://github.com/celery/celery/issues/4867 and perhaps https://github.com/celery/celery/issues/4608.  Celery version 4.1.1 doesn't have this issue.