### PR TITLE
[WIP] Use multistage builds to install sdist in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial as base
 
 RUN apt-get update && \
   apt-get install -qy software-properties-common python-software-properties && \
@@ -11,29 +11,29 @@ RUN apt-get update && \
     libssl-dev \
     libjpeg-dev \
     zlib1g-dev \
-    r-base \
     libpython-dev && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py
 
 
-WORKDIR /girder_worker
-COPY setup.py /girder_worker/setup.py
-COPY requirements.txt /girder_worker/requirements.txt
-COPY requirements.in /girder_worker/requirements.in
-COPY README.rst /girder_worker/README.rst
-COPY examples /girder_worker/examples
-COPY scripts /girder_worker/scripts
-COPY girder_worker /girder_worker/girder_worker
-COPY docker-entrypoint.sh /girder_worker/docker-entrypoint.sh
+FROM base as build
 
-RUN pip install -e .
+RUN apt-get update && apt-get install -qy git
+
+COPY ./ /girder_worker/
+WORKDIR /girder_worker
+
+RUN rm -rf ./dist && python setup.py sdist
+
+FROM base
+COPY --from=build /girder_worker/dist/*.tar.gz /
+COPY --from=build /girder_worker/docker-entrypoint.sh /docker-entrypoint.sh
+RUN pip install /*.tar.gz
 
 RUN useradd -D --shell=/bin/bash && useradd -m worker
 
-# RUN /usr/local/bin/girder-worker-config set girder_worker tmp_root /tmp
-RUN chown -R worker:worker /girder_worker
+RUN chown -R worker:worker /usr/local/lib/python2.7/dist-packages/girder_worker/
 
 USER worker
 
@@ -43,4 +43,4 @@ RUN girder-worker-config set celery broker "amqp://%(RABBITMQ_USER)s:%(RABBITMQ_
 
 VOLUME /girder_worker
 
-ENTRYPOINT ["./docker-entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile.py3
+++ b/Dockerfile.py3
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial as base
 
 RUN apt-get update && \
   apt-get install -qy software-properties-common python3-software-properties && \
@@ -18,29 +18,32 @@ RUN apt-get update && \
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 
 
-WORKDIR /girder_worker
-COPY setup.py /girder_worker/setup.py
-COPY requirements.txt /girder_worker/requirements.txt
-COPY requirements.in /girder_worker/requirements.in
-COPY README.rst /girder_worker/README.rst
-COPY examples /girder_worker/examples
-COPY scripts /girder_worker/scripts
-COPY girder_worker /girder_worker/girder_worker
-COPY docker-entrypoint.sh /girder_worker/docker-entrypoint.sh
+FROM base as build
 
-RUN pip3 install -e .
+RUN apt-get update && apt-get install -qy git
+
+COPY ./ /girder_worker/
+WORKDIR /girder_worker
+
+RUN rm -rf ./dist && python3 setup.py sdist
+
+
+FROM base
+COPY --from=build /girder_worker/dist/*.tar.gz /
+COPY --from=build /girder_worker/docker-entrypoint.sh /docker-entrypoint.sh
+RUN pip3 install /*.tar.gz
 
 RUN useradd -D --shell=/bin/bash && useradd -m worker
 
-# RUN /usr/local/bin/girder-worker-config set girder_worker tmp_root /tmp
-RUN chown -R worker:worker /girder_worker
+RUN chown -R worker:worker /usr/local/lib/python3.5/dist-packages/girder_worker/
 
 USER worker
 
 RUN girder-worker-config set celery broker "amqp://%(RABBITMQ_USER)s:%(RABBITMQ_PASS)s@%(RABBITMQ_HOST)s/"
 
+
 VOLUME /girder_worker
 
 ENV PYTHON_BIN=python3
 
-ENTRYPOINT ["./docker-entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
This uses multistage builds to copy the entire docker context into an
intermediate 'build' container. There we generate an sdist which is
copied into the final container where it is installed. This prevents
unfortunate artifacts like .git/ repos etc laying around and gets us
away from editable installs.

Currently this will break the integration testing infrastructure,  I will be fixing that next