### PR TITLE
Enforce relative paths for VolumePath

### DIFF
--- a/girder_worker/docker/transforms/__init__.py
+++ b/girder_worker/docker/transforms/__init__.py
@@ -306,6 +306,9 @@ class VolumePath(Transform):
             :py:attribute:`girder_worker.docker.transforms.TemporaryVolume.default`
         :type volume: :py:class:`girder_worker.docker.transforms.Connect`
         """
+        if os.path.isabs(filename):
+            raise Exception('VolumePath paths must be relative to a volume (%s).' % filename)
+
         self.filename = filename
         self._volume = volume
 


### PR DESCRIPTION
@cjh1 @kotfic PTAL

This is mostly meant to help developers who don't fully understand what they're doing (like me) with respect to IO in a docker_run task. If a user passes in an absolute path as the filename argument to VolumePath, they are almost certainly doing something wrong, and this error message will hopefully help them understand what they should do instead.