### PR TITLE
Call exception hooks on result transforms

### DIFF
--- a/girder_worker/docker/transforms/girder.py
+++ b/girder_worker/docker/transforms/girder.py
@@ -155,12 +155,17 @@ class GirderUploadVolumePathToFolder(GirderUploadToFolder):
 
 
 class GirderUploadVolumePathJobArtifact(GirderUploadJobArtifact):
-    def __init__(self, volumepath, job_id=None, name=None, **kwargs):
+    def __init__(self, volumepath, job_id=None, name=None, upload_on_exception=False, **kwargs):
         if job_id is not None:
             job_id = str(job_id)
         super(GirderUploadVolumePathJobArtifact, self).__init__(job_id, name, **kwargs)
         self._volumepath = volumepath
+        self._upload_on_exception = upload_on_exception
 
     def transform(self, *args, **kwargs):
         path = _maybe_transform(self._volumepath, *args, **kwargs)
         return super(GirderUploadVolumePathJobArtifact, self).transform(path)
+
+    def exception(self):
+        if self._upload_on_exception:
+            return self.transform()

--- a/girder_worker/task.py
+++ b/girder_worker/task.py
@@ -155,6 +155,11 @@ class Task(celery.Task):
                     results = self._maybe_transform_result(0, results)
 
             return results
+        except Exception:
+            if hasattr(self.request, 'girder_result_hooks'):
+                for hook in self.request.girder_result_hooks:
+                    hook.exception()
+            raise
         finally:
             _walk_obj(args, self._maybe_cleanup)
             _walk_obj(kwargs, self._maybe_cleanup)


### PR DESCRIPTION
Also make the GirderUploadVolumePathJobArtifact transform
optionally perform the upload if an exception occurs.