### PR TITLE
Expose timeout parameter

### DIFF
--- a/girder_worker/docker/tasks/__init__.py
+++ b/girder_worker/docker/tasks/__init__.py
@@ -46,7 +46,11 @@ def _pull_image(image):
 
 def _run_container(image, container_args,  **kwargs):
     # TODO we could allow configuration of non default socket
-    client = docker.from_env(version='auto')
+    if 'DOCKER_CLIENT_TIMEOUT' in os.environ:
+        timeout = int(os.environ['DOCKER_CLIENT_TIMEOUT'])
+        client = docker.from_env(version='auto', timeout=timeout)
+    else:
+        client = docker.from_env(version='auto')
 
     runtime = kwargs.pop('runtime', None)
     origRuntime = runtime

--- a/tests/integration/Dockerfile.girder
+++ b/tests/integration/Dockerfile.girder
@@ -1,4 +1,4 @@
-FROM girder/girder:latest
+FROM girder/girder:2.x-maintenance
 MAINTAINER Christopher Kotfila <chris.kotfila@kitware.com>
 
 RUN pip install ansible girder-client


### PR DESCRIPTION
Set the timeout kwarg on the docker python client based on an environment variable (DOCKER_CLIENT_TIMEOUT). Must be a number otherwise it would be ignored.