### PR TITLE
[WIP] Add automatic CLI generation from GW tasks

### DIFF
--- a/girder_worker/cli/__init__.py
+++ b/girder_worker/cli/__init__.py
@@ -1,0 +1,11 @@
+from girder_worker_utils.decorators import GWFuncDesc
+from girder_worker.cli.arguments import (
+    VarsArgCli,
+    KwargsArgCli,
+    PositionalArgCli,
+    KeywordArgCli)
+
+GWFuncDesc.VarsArgCls = VarsArgCli
+GWFuncDesc.KwargsArgCls = KwargsArgCli
+GWFuncDesc.PositionalArgCls = PositionalArgCli
+GWFuncDesc.KeywordArgCls = KeywordArgCli

--- a/girder_worker/cli/__main__.py
+++ b/girder_worker/cli/__main__.py
@@ -1,0 +1,94 @@
+import click
+import pkg_resources as pr
+from click.core import Command, Argument, Option
+from girder_worker.entrypoint import get_extensions, get_extension_tasks, import_all_includes
+from stevedore import driver
+from girder_worker_utils.decorators import (
+    GWFuncDesc,
+    Arg,
+    KWArg)
+
+GWRUN_ENTRYPOINT_GROUP = 'gwrun_output_handlers'
+
+def _cast_to_command(f):
+    if isinstance(f, Command):
+        return f
+
+    description = GWFuncDesc.get_description(f)
+    if description is not None:
+        for arg in reversed(description.arguments):
+            if isinstance(arg, KWArg):
+                if not hasattr(arg, 'cli_args'):
+                    cli_args = ('-{}'.format(arg.name), )
+                else:
+                    cli_args = arg.cli_args
+
+                if not hasattr(arg, 'cli_opts'):
+                    cli_opts = {}
+                else:
+                    cli_opts = arg.cli_opts
+
+                click.option(*cli_args, **cli_opts)(f)
+            elif isinstance(arg, Arg):
+                if not hasattr(arg, 'cli_args'):
+                    cli_args = (arg.name, )
+                else:
+                    cli_args = arg.cli_args
+
+                if not hasattr(arg, 'cli_opts'):
+                    cli_opts = {}
+                else:
+                    cli_opts = arg.cli_opts
+
+                click.argument(*cli_args, **cli_opts)(f)
+
+            else:
+                pass
+    return click.decorators.command()(f)
+
+
+def _iterate_tasks():
+    import_all_includes()
+    for extension in get_extensions():
+        if extension not in ('core', 'docker'):
+            for task in get_extension_tasks(extension).values():
+                yield task
+
+
+
+class GWCommand(click.MultiCommand):
+    def list_commands(self, ctx):
+        return [_cast_to_command(task).name for task in _iterate_tasks()]
+
+    def get_command(self, ctx, name):
+        for task in _iterate_tasks():
+            if task.description().func_name == name:
+                return _cast_to_command(task)
+
+    def __call__(self, *args, **kwargs):
+        return self.main(*args, **kwargs)
+
+
+
+@click.group(cls=GWCommand, invoke_without_command=True)
+@click.option('-o', '--output',
+              type=click.Choice([ep.name for ep in pr.iter_entry_points(GWRUN_ENTRYPOINT_GROUP)]),
+              default='stdout')
+@click.pass_context
+def main(ctx, output):
+    pass
+
+
+@main.resultcallback()
+def process_output(processors, output):
+    for ep in pr.iter_entry_points(GWRUN_ENTRYPOINT_GROUP):
+        if ep.name == output:
+            _handler = ep.load()
+            return _handler(processors)
+
+    # Throw warning here?
+    return processors
+
+
+if __name__ == '__main__':
+    main() #noqa

--- a/girder_worker/cli/arguments.py
+++ b/girder_worker/cli/arguments.py
@@ -1,0 +1,76 @@
+import click
+from girder_worker_utils.decorators import (
+    VarsArg,
+    KwargsArg,
+    PositionalArg,
+    KeywordArg)
+
+# TODO Implement MVP
+class VarsArgCli(VarsArg):
+    click_type = click.argument
+
+    def decorate(self, f):
+        pass
+
+    def get_args(self):
+        return []
+
+    def get_opts(self):
+        return {}
+
+
+# TODO Implement MVP
+class KwargsArgCli(KwargsArg):
+    click_type = click.argument
+
+    def decorate(self, f):
+        pass
+
+    def get_args(self):
+        return []
+
+    def get_opts(self):
+        return {}
+
+
+class PositionalArgCli(PositionalArg):
+
+    def decorate(self, f):
+        click.argument(*self.get_args(), **self.get_opts())(f)
+
+    def get_args(self):
+        if not hasattr(self, 'cli_args'):
+            cli_args = (self.name, )
+        else:
+            cli_args = self.cli_args
+
+        return cli_args
+
+    def get_opts(self):
+        if not hasattr(self, 'cli_opts'):
+            cli_opts = {}
+        else:
+            cli_opts = self.cli_opts
+
+        return cli_opts
+
+
+class KeywordArgCli(KeywordArg):
+    def decorate(self, f):
+        click.option(*self.get_args(), **self.get_opts())(f)
+
+    def get_opts(self):
+        if not hasattr(self, 'cli_opts'):
+            cli_opts = {}
+        else:
+            cli_opts = self.cli_opts
+
+        return cli_opts
+
+    def get_args(self):
+        if not hasattr(self, 'cli_args'):
+            cli_args = ('-{}'.format(self.name), )
+        else:
+            cli_args = self.cli_args
+
+        return cli_args

--- a/girder_worker/cli/handlers.py
+++ b/girder_worker/cli/handlers.py
@@ -1,0 +1,23 @@
+from functools import wraps
+import json
+
+def gwrun_output_handler(func):
+    @wraps(func)
+    def _handler(value, **kwargs):
+        # Call the function for its output side effects
+        func(value, **kwargs)
+
+        # Return the value unmodified
+        return value
+
+    return _handler
+
+
+@gwrun_output_handler
+def stdout_output_handler(value):
+    print(value)
+
+
+@gwrun_output_handler
+def json_output_handler(value):
+    print(json.dumps(value))

--- a/setup.py
+++ b/setup.py
@@ -123,11 +123,16 @@ setuptools.setup(
         'console_scripts': [
             'girder-worker = girder_worker.__main__:main',
             'girder-worker-cleanup = girder_worker.core.cleanup:main',
-            'girder-worker-config = girder_worker.configure:main'
+            'girder-worker-config = girder_worker.configure:main',
+            'gwrun = girder_worker.cli.__main__:main'
         ],
         'girder_worker_plugins': [
             'core = girder_worker:GirderWorkerPlugin',
             'docker = girder_worker.docker:DockerPlugin [docker]'
+        ],
+        'gwrun_output_handlers': [
+            'stdout = girder_worker.cli.handlers:stdout_output_handler',
+            'json = girder_worker.cli.handlers:json_output_handler',
         ],
         'girder_worker._test_plugins.valid_plugins': [
             'core = girder_worker._test_plugins.plugins:TestCore',


### PR DESCRIPTION
This PR relies on https://github.com/girder/girder_worker_utils/pull/30 and provides a proof of concept implementation that relies on a terrible argument metadata API for auto-generation of a girder worker CLI.  Consider the following girder worker task:

```python
import click
from girder_worker.app import app
from girder_worker_utils.decorators import parameter


@parameter('a', cli_opts={'type': click.INT})
@parameter('b', cli_opts={'type': click.INT})
@parameter('zero',
           cli_args=('-z', '--zero'),
           cli_opts={'type': click.BOOL,
                     'help': 'return "undefined" if dividing by zero'})
@app.task(bind=True)
def divide(self, a, b, zero=False):
    if zero and b == 0:
        return 'undefined'

    return a / b
```

This implements a gwrun command that automatically discovers installed tasks and provides a click based application. E.g.: 


```sh
⇒ gwrun --help
Usage: gwrun [OPTIONS] COMMAND [ARGS]...

Options:
  -o, --output [json|stdout]
  --help                      Show this message and exit.

Commands:
  divide    Proxy that evaluates object once.

```
And

```sh
 ⇒ gwrun divide --help
Usage: gwrun divide [OPTIONS] A B

  Proxy that evaluates object once.

  :class:`Proxy` will evaluate the object each time, while the promise will
  only evaluate it once.

Options:
  -z, --zero BOOLEAN  return "undefined" if dividing by zero
  --help              Show this message and exit.

```

Finally

```sh
⇒ gwrun divide 2 2     
1.0
```

The `cli_args` and `cli_opts` implementation (which is obviously ugly and confusing) are designed to be the low-level API on which a more intuitive and "intelligent" API may be built.  For instance:

```python
@parameter('a', type=float)
@parameter('b', type=float)
@app.task
def add(a, b):
    return a + b
``` 
represents a much nicer API and a mapping could be used to negotiate the difference between `type=float` and `cli_opts={'type': click.FLOAT}` behind the scenes. This serves the purpose of:

1. Improving the readability of the API for the majority usecase
2. Supporting a similar abstraction for handling automatic generation of a web UI 


_Note_ that this also attempts to implement basic output handling whereby the return value of the function may be directly printed to stdout (e.g. \_\_repr\_\_) or serialized to json before being printed. 