### PR TITLE
Add timeout variable to the busybox container

### DIFF
--- a/girder_worker/docker/utils.py
+++ b/girder_worker/docker/utils.py
@@ -74,7 +74,12 @@ def chmod_writable(host_paths):
     if not isinstance(host_paths, (list, tuple)):
         host_paths = (host_paths,)
 
-    client = docker.from_env(version='auto')
+    if 'DOCKER_CLIENT_TIMEOUT' in os.environ:
+        timeout = int(os.environ['DOCKER_CLIENT_TIMEOUT'])
+        client = docker.from_env(version='auto', timeout=timeout)
+    else:
+        client = docker.from_env(version='auto')
+
     config = {
         'tty': True,
         'volumes': {},


### PR DESCRIPTION
We realized busybox container is also timing out. This adds the same snippet which checks 
the environment variables for the DOCKER_CLIENT_TIMEOUT value. 