### PR TITLE
Expose some config behavior to utils.

### DIFF
--- a/girder_worker/core/utils.py
+++ b/girder_worker/core/utils.py
@@ -88,13 +88,7 @@ def toposort(data):
 @contextlib.contextmanager
 def tmpdir(cleanup=True):
     # Make the temp dir underneath tmp_root config setting
-    root = os.path.abspath(girder_worker.config.get(
-        'girder_worker', 'tmp_root'))
-    try:
-        os.makedirs(root)
-    except OSError:
-        if not os.path.isdir(root):
-            raise
+    root = girder_worker.utils.get_tmp_root()
     path = tempfile.mkdtemp(dir=root)
 
     try:

--- a/girder_worker/plugins/girder_io/__init__.py
+++ b/girder_worker/plugins/girder_io/__init__.py
@@ -1,8 +1,10 @@
 import girder_client
 import json
 import os
-from girder_worker import config
 from six import StringIO
+
+import girder_worker
+from girder_worker import config
 
 # Make a sensible limit for metadata outputs
 MAX_METADATA_LENGTH = 4 * 1024 * 1024  # 4MB
@@ -96,7 +98,7 @@ def fetch_handler(spec, **kwargs):
             # If we fetch the parent, we can't use direct paths as the
             # task may needs all of the siblings next to each other
             dest = _fetch_parent_item(spec['id'], client, kwargs['_tempdir'])
-        elif (direct_path and config.getboolean('girder_io', 'allow_direct_path') and
+        elif (direct_path and girder_worker.utils.allow_direct_path() and
                 os.path.isfile(direct_path)):
             # If the specification includes a direct path AND it is allowed by
             # the worker configuration AND it is a reachable file, use it.

--- a/girder_worker/utils.py
+++ b/girder_worker/utils.py
@@ -1,3 +1,4 @@
+import os
 import time
 from celery.task.control import inspect
 
@@ -6,6 +7,7 @@ from girder_worker_utils.tee import Tee, tee_stderr, tee_stdout
 import requests
 from requests import HTTPError
 
+from girder_worker import config
 
 import six
 
@@ -322,3 +324,30 @@ class JobManager(object):
         self.status = r.json()['status']
 
         return self.status
+
+
+def get_tmp_root():
+    """
+    Get the directory where temp directories should be created.  The results
+    can be used like `tempfile.mkdtemp(dir=get_tmp_root())`.
+
+    :returns: a directory where temp directories should be created.  This could
+        be None to use the system default.  Otherwise it is a directory that
+        exists.
+    """
+    root = os.path.abspath(config.get('girder_worker', 'tmp_root'))
+    try:
+        os.makedirs(root)
+    except OSError:
+        if not os.path.isdir(root):
+            raise
+    return root
+
+
+def allow_direct_path():
+    """
+    Check if direct paths are allowed.
+
+    :returns: True if direct paths are allowed.
+    """
+    return config.getboolean('girder_io', 'allow_direct_path')


### PR DESCRIPTION
Move the logic for getting the temporary directory root to the utils module.  Move the logic for determine if direct paths are allowed to the utils module.

This will allow girder_worker_utils to access these values without using the girder_worker.config object.