### PR TITLE
Add a guard around getting a local file path.

### DIFF
--- a/girder_worker/girder_plugin/utils.py
+++ b/girder_worker/girder_plugin/utils.py
@@ -96,11 +96,9 @@ def girderInputSpec(resource, resourceType='file', name=None, token=None,
         # that location.  This can permit the user of the specification to
         # access the file directly instead of downloading the file.
         try:
-            direct_path = File().getLocalFilePath(resource)
+            result['direct_path'] = File().getLocalFilePath(resource)
         except FilePathException:
-            direct_path = None
-        if direct_path is not None:
-            result['direct_path'] = direct_path
+            pass
     return result
 
 

--- a/girder_worker/girder_plugin/utils.py
+++ b/girder_worker/girder_plugin/utils.py
@@ -19,6 +19,7 @@
 
 from .constants import PluginSettings
 from girder.api.rest import getApiUrl
+from girder.exceptions import FilePathException
 from girder.models.file import File
 from girder.models.setting import Setting
 from girder.utility import setting_utilities
@@ -94,7 +95,10 @@ def girderInputSpec(resource, resourceType='file', name=None, token=None,
         # If we are adding a file and it exists on the local filesystem include
         # that location.  This can permit the user of the specification to
         # access the file directly instead of downloading the file.
-        direct_path = File().getLocalFilePath(resource)
+        try:
+            direct_path = File().getLocalFilePath(resource)
+        except FilePathException:
+            direct_path = None
         if direct_path is not None:
             result['direct_path'] = direct_path
     return result


### PR DESCRIPTION
This is necessary for old-style girder_worker jobs using non-filesystem assetstores.