### PR TITLE
Properly serialize task kwargs in a nongirder context. Fixes #337

### DIFF
--- a/girder_worker/context/nongirder_context.py
+++ b/girder_worker/context/nongirder_context.py
@@ -49,7 +49,7 @@ def create_task_job(job_defaults, sender=None, body=None,
             'public': headers.pop('girder_job_public',
                                   job_defaults.get('girder_job_public', '')),
             'args': json.dumps(task_args),
-            'kwargs': task_kwargs,
+            'kwargs': json.dumps(task_kwargs),
             'otherFields': json.dumps(
                 dict(celeryTaskId=headers['id'],
                      celeryParentTaskId=parent_task.request.id,

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -128,6 +128,17 @@ def test_celery_chained_tasks(session):
     assert jobs[0]['parentId'] == jobs[1]['_id']
 
 
+def test_celery_chained_tasks_with_kwargs(session):
+    url = 'integration_tests/celery/test_task_chained_with_kwargs'
+    r = session.post(url)
+    assert r.status_code == 200, r.content
+    jobs = r.json()
+    # Check if kwargs are correctly set
+    assert jobs[2]['kwargs'] == dict(foo=1, bar=2)
+    assert jobs[1]['kwargs'] == dict(baz=3)
+    assert jobs[0]['kwargs'] == dict(last_but_not_least=4)
+
+
 def test_celery_chained_task_bad_token_fails(session):
     r = session.post('integration_tests/celery/test_task_chained_bad_token_fails')
     assert r.status_code == 200, r.content


### PR DESCRIPTION
`kwargs` argument passed to `POST /job` was not properly serialized.