### PR TITLE
Include [girder] in installation command.

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -17,7 +17,7 @@ Installing Girder Worker
 
 Girder Worker is a python package and may be installed with pip ::
 
-  $ pip install girder-worker
+  $ pip install girder-worker[girder]
 
 We recommend installing in a virtual environment to prevent package
 collision with your system Python.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,12 @@ Installation
 ************
 
 To install the Girder Worker on your system, we recommend using ``pip`` to
-install the package. ::
+install the package.  Girder worker needs to be installed as a plugin to Girder
+and on each remote machine.  For the system with Girder ::
+
+    pip install girder-worker[girder]
+
+For other machines ::
 
     pip install girder-worker
 


### PR DESCRIPTION
The installation as a Girder plugin requires the `[girder]` extra requires or knowledge of other dependencies.  Change the docs to make this a little clearer.