### PR TITLE
Only send log value if it has data

### DIFF
--- a/girder_worker/utils.py
+++ b/girder_worker/utils.py
@@ -226,15 +226,17 @@ class JobManager(object):
 
         if len(self._buf) or self._progressTotal or self._progressMessage or \
                 self._progressCurrent is not None:
+            data = {
+                'progressTotal': self._progressTotal,
+                'progressCurrent': self._progressCurrent,
+                'progressMessage': self._progressMessage
+            }
+            if self._buf:
+                data['log'] = self._buf
 
             req = requests.request(
                 self.method.upper(), self.url, allow_redirects=True,
-                headers=self.headers, data={
-                    'log': self._buf,
-                    'progressTotal': self._progressTotal,
-                    'progressCurrent': self._progressCurrent,
-                    'progressMessage': self._progressMessage
-                })
+                headers=self.headers, data=data)
             req.raise_for_status()
             self._buf = b''
 


### PR DESCRIPTION
Girder's server-side handler writes data to the job log even if it's just an empty string, which ends up writing e.g. `["", "", "", ""]` to the database, growing linearly with each progress update event. It's debatable whether that server side behavior is desirable, however it's easy enough to handle it here and only send the log value if something has been written to it.