### PR TITLE
Import ConfigParser, not SafeConfigParser

### DIFF
--- a/girder_worker/__init__.py
+++ b/girder_worker/__init__.py
@@ -1,6 +1,6 @@
 import os
 from pkg_resources import DistributionNotFound, get_distribution
-from six.moves.configparser import SafeConfigParser
+from configparser import ConfigParser
 
 from . import log_utils
 
@@ -19,7 +19,7 @@ PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 _cfgs = ('worker.dist.cfg', 'worker.local.cfg')
 
 
-config = SafeConfigParser({
+config = ConfigParser({
     'RABBITMQ_USER': os.environ.get('RABBITMQ_USER', 'guest'),
     'RABBITMQ_PASS': os.environ.get('RABBITMQ_PASS', 'guest'),
     'RABBITMQ_HOST': os.environ.get('RABBITMQ_HOST', 'localhost')


### PR DESCRIPTION
This project currently imports the name `SafeConfigParser` from the `configparser` module, which generates the following DeprecationWarning:

```
The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
```

As this project only supports Python 3.6 and up (according to its classifiers), there is no reason to continue importing a deprecated name, and so this PR updates the code to import `ConfigParser` instead.  Similarly, there is no need to import via `six`, so that part of the import statement is dropped.