### PR TITLE
Add `python_requires` to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setuptools.setup(
         'install': CustomInstall
     },
     install_requires=install_reqs,
+    python_requires='>=3.6',
     zip_safe=False,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This package's classifiers indicate that it only supports Python 3.6 and up.  This PR thus sets the package's `Requires-Python` metadata to `>= 3.6` so that pip will refuse to install it on older Python versions (Classifiers by themselves do nothing).