### PR TITLE
Add requests parameters for communication with Girder

### DIFF
--- a/docs/using-from-girder.rst
+++ b/docs/using-from-girder.rst
@@ -64,3 +64,32 @@ be passed into the function in place of the transform object. For example:
 
     def process_file(file):
         return my_task.delay(input_file=GirderFileId(file['_id'])).job
+
+
+Customizing communication back to Girder server
+-----------------------------------------------
+
+Girder Worker is bound to communicate with a Girder instance to update the information about running jobs or download files from the assetstore.  
+In some scenarios, you might want to customize the HTTP communication back to the Girder server.
+  
+Girder Worker uses the Python library ``requests`` to communicate over HTTP and creates a `requests.Session() <https://docs.python-requests.org/en/master/user/advanced/#session-objects>`_ instance that can be adjusted by providing a ``girder_client_session_kwargs`` kwarg in the task parameters.
+
+Here are examples of using ``girder_client_session_kwargs``:
+
+.. code-block:: python
+
+    kwargs = {
+        'girder_client_session_kwargs': {'verify': False}
+    }
+    task.apply_async((), kwargs)
+
+This will disable TLS certificate validation when communicating with Girder.
+
+.. code-block:: python
+
+    kwargs = {
+        'girder_client_session_kwargs': {'headers': {'x-test': 'true'}}
+    }
+    task.apply_async((), kwargs)
+
+This will set the headers of any subsequent request to `{'x-test': 'true'}`

--- a/girder_worker/task.py
+++ b/girder_worker/task.py
@@ -50,7 +50,8 @@ class Task(celery.Task):
     reserved_headers = [
         'girder_client_token',
         'girder_api_url',
-        'girder_result_hooks']
+        'girder_result_hooks',
+        'girder_client_session_kwargs']
 
     # These keys will be available in the 'properties' dictionary inside
     # girder_before_task_publish() but will not be passed along in the message

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,7 +15,8 @@ import pytest
 RESERVED_HEADERS = [
     ('girder_client_token', 'GIRDER_CLIENT_TOKEN'),
     ('girder_api_url', 'GIRDER_API_URL'),
-    ('girder_result_hooks', 'GIRDER_RESULT_HOOKS')
+    ('girder_result_hooks', 'GIRDER_RESULT_HOOKS'),
+    ('girder_client_session_kwargs', 'GIRDER_CLIENT_SESSION_KWARGS')
 ]
 
 RESERVED_OPTIONS = [


### PR DESCRIPTION
Add a way to specify arguments that will be set to a requests session used for following requests to Girder.