### PR TITLE
Set sessions to retry connections.

### DIFF
--- a/girder_worker/utils.py
+++ b/girder_worker/utils.py
@@ -219,6 +219,9 @@ class JobManager(object):
         self._progressMessage = None
 
         self._session = requests.Session()
+        retryAdapter = requests.adapters.HTTPAdapter(max_retries=10)
+        self._session.mount('http://', retryAdapter)
+        self._session.mount('https://', retryAdapter)
 
         if girder_client_session_kwargs:
             for attr, value in girder_client_session_kwargs.items():

--- a/tests/task_signal_test.py
+++ b/tests/task_signal_test.py
@@ -224,6 +224,7 @@ class TestSignals(unittest.TestCase):
                 self.response = self.request.return_value
                 self.response.raise_for_status.side_effect = [
                     MockHTTPError(400, validation_error), None]
+                self.adapters = {}
 
         with unittest.mock.patch(
             'girder_worker.utils.requests.Session'
@@ -271,6 +272,7 @@ class TestSignals(unittest.TestCase):
                 self.response = self.request.return_value
                 self.response.raise_for_status.side_effect = [
                     None, MockHTTPError(400, validation_error)]
+                self.adapters = {}
 
         with unittest.mock.patch(
             'girder_worker.utils.requests.Session'


### PR DESCRIPTION
As of PR #376, we are using request sessions by default.  If a job doesn't emit output for a long time, then tries to emit output, that session object might have been disconnected by the server, at which point the job fails.  Allowing any retries fixes this.

Perhaps there is a better way to have both sessions and not have to add a retry adapter.