### PR TITLE
Clean up docker tasks' temp directory after exceptions

### DIFF
--- a/girder_worker/docker/tasks/__init__.py
+++ b/girder_worker/docker/tasks/__init__.py
@@ -336,11 +336,13 @@ class DockerTask(Task):
 
         volumes.update(default_temp_volume._repr_json_())
 
-        super().__call__(*args, **kwargs)
-        threading.Thread(
-            target=self._cleanup_temp_volumes,
-            args=(temp_volumes, default_temp_volume),
-            daemon=True).start()
+        try:
+            super().__call__(*args, **kwargs)
+        finally:
+            threading.Thread(
+                target=self._cleanup_temp_volumes,
+                args=(temp_volumes, default_temp_volume),
+                daemon=True).start()
 
     def _cleanup_temp_volumes(self, temp_volumes, default_temp_volume):
         # Set the permission to allow cleanup of temp directories

--- a/girder_worker/task.py
+++ b/girder_worker/task.py
@@ -123,14 +123,15 @@ class Task(celery.Task):
     def describe(self):
         return describe_function(self.run)
 
-    def call_item_task(self, inputs, outputs={}):
+    def call_item_task(self, inputs, outputs=None):
+        if outputs is None:
+            outputs = {}
         return self.run.call_item_task(inputs, outputs)
 
     def _maybe_transform_result(self, idx, result, **kwargs):
         try:
             grh = self.request.girder_result_hooks[idx]
-            if hasattr(grh, 'transform') and \
-               callable(grh.transform):
+            if hasattr(grh, 'transform') and callable(grh.transform):
                 return grh.transform(result, **kwargs)
             return result
         except IndexError:


### PR DESCRIPTION
Before, a docker task that failed would abandon its temp directory.