### PR TITLE
Undo the workaround for docker and request conflict

### DIFF
--- a/girder_worker/docker/tasks/__init__.py
+++ b/girder_worker/docker/tasks/__init__.py
@@ -1,5 +1,4 @@
 import datetime
-import importlib.metadata
 import os
 import shutil
 import socket
@@ -35,13 +34,6 @@ from girder_worker_utils import _walk_obj
 
 
 BLACKLISTED_DOCKER_RUN_ARGS = ['tty', 'detach']
-
-# Work around an issue with docker and requests
-if (importlib.metadata.version('docker') == '7.0.0' and
-        not hasattr(docker.transport.basehttpadapter.BaseHTTPAdapter, '_get_connection')):
-    docker.transport.basehttpadapter.BaseHTTPAdapter._get_connection = (
-        lambda self, request, *args, proxies=None, **kwargs: self.get_connection(
-            request.url, proxies))
 
 
 def _pull_image(image):

--- a/girder_worker/docker/utils.py
+++ b/girder_worker/docker/utils.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import os
 import select
 import uuid
@@ -7,12 +6,6 @@ import docker
 from docker.errors import DockerException
 
 from girder_worker import logger
-
-if (importlib.metadata.version('docker') == '7.0.0' and
-        not hasattr(docker.transport.basehttpadapter.BaseHTTPAdapter, '_get_connection')):
-    docker.transport.basehttpadapter.BaseHTTPAdapter._get_connection = (
-        lambda self, request, *args, proxies=None, **kwargs: self.get_connection(
-            request.url, proxies))
 
 
 def select_loop(exit_condition=lambda: True, readers=None, writers=None):


### PR DESCRIPTION
Python docker 7.1.0 should work with most versions of requests.