### PR TITLE
Improve Docker entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-BIN=${PYTHON_BIN:-python}
-
-# TODO: Change this to use celery command once py2 support is dropped.
-/usr/bin/env RABBITMQ_USER=${RABBITMQ_USER:-guest} \
-             RABBITMQ_PASS=${RABBITMQ_PASS:-guest} \
-             RABBITMQ_HOST=${RABBITMQ_HOST:-localhost} \
-             $BIN -m girder_worker -l info
+RABBITMQ_USER=${RABBITMQ_USER:-guest} \
+RABBITMQ_PASS=${RABBITMQ_PASS:-guest} \
+RABBITMQ_HOST=${RABBITMQ_HOST:-localhost} \
+celery -A girder_worker.app worker -l INFO $@


### PR DESCRIPTION
 - Drop Python2 support
 - Allow extra argument to be passed via `docker run`
 - Use celery instead of girder_worker which processes more env variables