### PR TITLE
Change how we find the worker's network

### DIFF
--- a/girder_worker/docker/tasks/__init__.py
+++ b/girder_worker/docker/tasks/__init__.py
@@ -49,6 +49,10 @@ def _pull_image(image):
         raise
 
 
+def _is_no_such_container(exc):
+    return 'No such container' in str(exc) or type(exc).__name__ == 'NotFound'
+
+
 def _get_docker_network():
     try:
         ip = socket.gethostbyname(socket.gethostname())
@@ -57,10 +61,23 @@ def _get_docker_network():
             client = docker.from_env(version='auto', timeout=timeout)
         else:
             client = docker.from_env(version='auto')
-        for container in client.containers.list(all=True, filters={'status': 'running'}):
-            for nw in container.attrs['NetworkSettings']['Networks'].values():
+        # we use client.api.containers rather than client.containers.list
+        # because containers.lists casts to a list which can throw an
+        # exception rather than allowing graceful handling.
+        for container in client.api.containers(all=True, filters={'status': ['running']}):
+            cid = container.get('Id') or container.get('ID')
+            if not cid:
+                continue
+            try:
+                data = client.api.inspect_container(cid)
+            except Exception as exc:
+                if _is_no_such_container(exc):
+                    continue
+                raise
+            networks = (data.get('NetworkSettings', {}) or {}).get('Networks', {}) or {}
+            for nw in networks.values():
                 if nw['IPAddress'] == ip:
-                    return 'container:%s' % container.id
+                    return 'container:%s' % cid
     except Exception:
         logger.exception('Failed to get docker network')
 
@@ -68,12 +85,23 @@ def _get_docker_network():
 def _remove_stopped_container(client, name):
     if name is None:
         return
-    for container in client.containers.list(all=True, filters={'name': name}):
-        try:
-            logger.info('Removing container %s ' % (name))
-            container.remove()
-        except Exception:
-            pass
+    # we use client.api.containers rather than client.containers.list
+    # because containers.lists casts to a list which can throw an
+    # exception rather than allowing graceful handling.
+    try:
+        for container in client.api.containers(all=True, filters={'name': [name]}):
+            cid = container.get('Id') or container.get('ID')
+            if not cid:
+                continue
+            try:
+                logger.info('Removing container %s ' % (name))
+                client.api.remove_container(cid)
+            except Exception:
+                pass
+    except Exception as exc:
+        if _is_no_such_container(exc):
+            return
+        raise
 
 
 def _run_container(image, container_args,  **kwargs):


### PR DESCRIPTION
We enumerate docker containers to find the primary worker's network so we can attach jobs to the same network, allowing them to reference girder the same way as the worker.  If the containers mutate while we are listing them, this can throw can an error an prevent network location.  The docker python script has two methods of getting the container list; one is an iterator and the other is just a list() of the iterator.  But if the iterator throws while iterating, we don't don't anything from the list(), whereas if we use the iterator we can still proceed.