### PR TITLE
Make job_manager and girder_client per request

### DIFF
--- a/girder_worker/task.py
+++ b/girder_worker/task.py
@@ -172,3 +172,19 @@ class Task(celery.Task):
             if hasattr(self.request, 'girder_result_hooks'):
                 for hook in self.request.girder_result_hooks:
                     self._maybe_cleanup(hook)
+
+    @property
+    def job_manager(self):
+        return getattr(self.request, 'girder_job_manager', None)
+
+    @job_manager.setter
+    def job_manager(self, value):
+        self.request.girder_job_manager = value
+
+    @property
+    def girder_client(self):
+        return getattr(self.request, 'girder_client_instance', None)
+
+    @girder_client.setter
+    def girder_client(self, value):
+        self.request.girder_client_instance = value


### PR DESCRIPTION
We had set the job_manager and girder_client per task, but if we start two tasks at close to the same time this could result in the two tasks sharing the same job manager and girder client, resulting in one task ending up with the output streams from both tasks.  By making these per request, which are always distinct, this avoids the issue.