### PR TITLE
When using a celery threads-pool for the workers, do not tee logPrint

### DIFF
--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -12,7 +12,6 @@ from celery.signals import (
     task_prerun,
     task_revoked,
     task_success,
-    worker_init,
     worker_ready)
 
 
@@ -99,15 +98,23 @@ def girder_before_task_publish(sender=None, body=None, exchange=None,
         raise
 
 
-@worker_init.connect
+@worker_ready.connect
 def _capture_celery_pool(sender, **kwargs):
-    # sender is the celery.worker.worker.Worker instance
-    pool_cls = getattr(sender, 'pool_cls', None)
-    if pool_cls:
-        # pool_cls can be a class or string representing the pool
-        name = getattr(pool_cls, '__name__', str(pool_cls)).lower()
-        if 'thread' in name:
+    """
+    Determine if the celery task pool is thread based; we use this to govern
+    some logging choices.
+
+    :param sender:  a celery.worker.worker.Worker instance
+    """
+    pool = getattr(sender, 'pool', None)
+    try:
+        if pool and 'thread' in type(pool).__module__.lower():
             CeleryAppInfo['threads_pool'] = True
+            logger.info('Using a threads pool')
+        else:
+            logger.info('Not using a threads pool')
+    except Exception:
+        logger.exception('Failed to determine pool type')
 
 
 @worker_ready.connect

--- a/girder_worker/app.py
+++ b/girder_worker/app.py
@@ -12,6 +12,7 @@ from celery.signals import (
     task_prerun,
     task_revoked,
     task_success,
+    worker_init,
     worker_ready)
 
 
@@ -35,6 +36,8 @@ from girder_worker_utils.transform import ResultTransform
 
 import jsonpickle
 from kombu.serialization import register
+
+CeleryAppInfo = {'threads_pool': False}
 
 
 @before_task_publish.connect  # noqa: C901
@@ -94,6 +97,17 @@ def girder_before_task_publish(sender=None, body=None, exchange=None,
     except Exception:
         logger.exception('An error occurred in girder_before_task_publish.')
         raise
+
+
+@worker_init.connect
+def _capture_celery_pool(sender, **kwargs):
+    # sender is the celery.worker.worker.Worker instance
+    pool_cls = getattr(sender, 'pool_cls', None)
+    if pool_cls:
+        # pool_cls can be a class or string representing the pool
+        name = getattr(pool_cls, '__name__', str(pool_cls)).lower()
+        if 'thread' in name:
+            CeleryAppInfo['threads_pool'] = True
 
 
 @worker_ready.connect

--- a/girder_worker/utils.py
+++ b/girder_worker/utils.py
@@ -211,8 +211,9 @@ class JobManager:
         """
         from .app import CeleryAppInfo
 
-        # When we are using a threads pool, tee-ing the workers can lead to
-        # the logs being written to multiple threads.
+        # When we are using a threads pool, tee-ing stdout and stderr to
+        # logPrint can lead to the logs being written to multiple threads and
+        # therefore multiple workers.
         if CeleryAppInfo['threads_pool']:
             logPrint = None
         self.logPrint = logPrint

--- a/girder_worker/utils.py
+++ b/girder_worker/utils.py
@@ -209,6 +209,12 @@ class JobManager:
         :type interval: int or float
         :param reference: optional reference to store with the job.
         """
+        from .app import CeleryAppInfo
+
+        # When we are using a threads pool, tee-ing the workers can lead to
+        # the logs being written to multiple threads.
+        if CeleryAppInfo['threads_pool']:
+            logPrint = None
         self.logPrint = logPrint
         self.method = method or 'PUT'
         self.url = url


### PR DESCRIPTION
When we are using a threads pool, tee-ing the logPrint output can lead to the logs being written to multiple threads and therefore showing up to multiple workers
